### PR TITLE
_once_ feature and documentation to instantiate

### DIFF
--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -451,3 +451,14 @@ def recisinstance(got: Any, expected: Any) -> bool:
 
 
 an_object = object()
+
+_counts = {}
+
+def counter_function(key = None):
+    _counts[key] = _counts.get(key, 0) + 1
+    return _counts[key], key
+
+
+def counter_function2(key=None):
+    _counts[key] = _counts.get(key, 0) + 1
+    return _counts[key], key, "counter_function2"

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -2387,7 +2387,7 @@ def test_instantiated_once_nested(
     assert x.ref2 == (1, "test9")
 
 
-def test_instantiated_once_clear_cache(
+def test_instantiated_once_custom_cache(
     instantiate_func: Any,
 ) -> None:
     # Changing _recursive_ makes new signature for auto key.
@@ -2395,17 +2395,31 @@ def test_instantiated_once_clear_cache(
         "base": {
             "_target_": "tests.instantiate.counter_function",
             "_once_": True,
-            "key": "test9",
+            "key": "test10",
         },
         "ref1": "${base}",
         "ref2": "${base}",
     }
-    x = instantiate_func(cfg)
-    assert x.base == (1, "test9")
-    assert x.ref1 == (1, "test9")
-    assert x.ref2 == (1, "test9")
 
-    x = instantiate_func(cfg)
-    assert x.base == (1, "test9")
-    assert x.ref1 == (1, "test9")
-    assert x.ref2 == (1, "test9")
+    # you can specify a custom cache too.
+    cache = {}
+    x = instantiate_func(cfg, cache=cache)
+    assert x.base == (1, "test10")
+    assert x.ref1 == (1, "test10")
+    assert x.ref2 == (1, "test10")
+
+    x = instantiate_func(cfg, cache=cache)
+    assert x.base == (1, "test10")
+    assert x.ref1 == (1, "test10")
+    assert x.ref2 == (1, "test10")
+
+    # this way, the is cache is ephermeral.
+    x = instantiate_func(cfg, cache={})
+    assert x.base == (2, "test10")
+    assert x.ref1 == (2, "test10")
+    assert x.ref2 == (2, "test10")
+
+    x = instantiate_func(cfg, cache={})
+    assert x.base == (3, "test10")
+    assert x.ref1 == (3, "test10")
+    assert x.ref2 == (3, "test10")

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -380,6 +380,42 @@ assert bar1.foo is bar2.foo  # the `Foo` instance is re-used here
 This does not apply if `_partial_=False`,
 in which case a new `Foo` instance would be created with each call to `instantiate`.
 
+### Once-only instantiation
+
+If you want to ensure that a given object is instantiated only once and reused, 
+set the `_once_` key to `True` in the config. Hydra will cache the object based
+on an md5 hash of the config yaml. 
+```yaml
+# config.yaml 
+foo:
+  _target_: my_app.Foo
+  _once_: true
+
+bar:
+  foo1: ${foo}
+  foo2: ${foo}
+```
+Now, instantiate will render `foo`, `bar.foo1` and `bar.foo2` as the same object,
+even when calling instantiate multiple times or in nested invocations.
+
+To use a manaully specified key, set the `_key_` to a unique string value.
+This usually should not be necessary.
+
+```yaml
+# config.yaml 
+foo:
+  _target_: my_app.Foo
+  _once_: true
+  _key_: my_unique_key
+bar:
+  foo1: ${foo}
+  foo2: ${foo}
+```
+
+Here also, 
+All the other instantiation parameters are still valid, including `_recursive_`,
+ `_partial_`, and `_convert_`.
+
 
 ### Instantiation of builtins
 

--- a/website/versioned_docs/version-1.3/advanced/instantiate_objects/overview.md
+++ b/website/versioned_docs/version-1.3/advanced/instantiate_objects/overview.md
@@ -393,6 +393,42 @@ from hydra.utils import instantiate
 instantiate({"_target_": "builtins.len"}, [1,2,3])  # this works, returns the number 3
 ```
 
+### Once-only instantiation
+
+If you want to ensure that a given object is instantiated only once and reused, 
+set the `_once_` key to `True` in the config. Hydra will cache the object based
+on an md5 hash of the config yaml. 
+```yaml
+# config.yaml 
+foo:
+  _target_: my_app.Foo
+  _once_: true
+
+bar:
+  foo1: ${foo}
+  foo2: ${foo}
+```
+Now, instantiate will render `foo`, `bar.foo1` and `bar.foo2` as the same object,
+even when calling instantiate multiple times or in nested invocations.
+
+To use a manaully specified key, set the `_key_` to a unique string value.
+This usually should not be necessary.
+
+```yaml
+# config.yaml 
+foo:
+  _target_: my_app.Foo
+  _once_: true
+  _key_: my_unique_key
+bar:
+  foo1: ${foo}
+  foo2: ${foo}
+```
+
+Here also, 
+All the other instantiation parameters are still valid, including `_recursive_`,
+ `_partial_`, and `_convert_`.
+
 ### Dotpath lookup machinery
 
 Hydra looks up a given `_target_` by attempting to find a module that

--- a/website/versioned_docs/version-1.3/advanced/instantiate_objects/overview.md
+++ b/website/versioned_docs/version-1.3/advanced/instantiate_objects/overview.md
@@ -393,42 +393,6 @@ from hydra.utils import instantiate
 instantiate({"_target_": "builtins.len"}, [1,2,3])  # this works, returns the number 3
 ```
 
-### Once-only instantiation
-
-If you want to ensure that a given object is instantiated only once and reused, 
-set the `_once_` key to `True` in the config. Hydra will cache the object based
-on an md5 hash of the config yaml. 
-```yaml
-# config.yaml 
-foo:
-  _target_: my_app.Foo
-  _once_: true
-
-bar:
-  foo1: ${foo}
-  foo2: ${foo}
-```
-Now, instantiate will render `foo`, `bar.foo1` and `bar.foo2` as the same object,
-even when calling instantiate multiple times or in nested invocations.
-
-To use a manaully specified key, set the `_key_` to a unique string value.
-This usually should not be necessary.
-
-```yaml
-# config.yaml 
-foo:
-  _target_: my_app.Foo
-  _once_: true
-  _key_: my_unique_key
-bar:
-  foo1: ${foo}
-  foo2: ${foo}
-```
-
-Here also, 
-All the other instantiation parameters are still valid, including `_recursive_`,
- `_partial_`, and `_convert_`.
-
 ### Dotpath lookup machinery
 
 Hydra looks up a given `_target_` by attempting to find a module that


### PR DESCRIPTION

## Motivation

Sometimes we want to ensure a subtree of the config is instantiated only ONCE. Making unnecessary copies, in these cases, can hammer resources or even break code.

Take this example:

```yaml
dataset:
  _target_: lightly.data.LightlyDataset
  root: data_dir
loader:
  _target_: torch.utils.data.DataLoader
  dataset: ${..dataset}  
  sampler:
    _target_: torch.utils.data.RandomSampler
    data_source: ${..dataset}.
```

Instantiating this config will, in fact, instantiate three separate instances of 'dataset', which is undesirable, because each one takes up memory. Even worse, calling instantiate a second time will create 3 more instances!

## Pitch

I'd like this to be a built in feature of hydra (requiring just a minor version bump), using this syntax instead:

```yaml
dataset:
  _target_: lightly.data.LightlyDataset
  _once_: true                     # instantiate will only create this tree once, reusing it when needed.
  _key_: unique_key # OPTIONAL: use this key, instead of the default hash of the yaml
  root: data_dir
loader:
  _target_: torch.utils.data.DataLoader
  dataset: ${..dataset}  
  sampler:
    _target_: torch.utils.data.RandomSampler
    data_source: ${..dataset}
```

This change is fully backwards compatible, and this PR passes all tests. It can be introduced initially beta in a patch release, or in a minor release. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

No special set up. Several tests added to tests/instantiate.py that verify correct behaivior. No existing tests fail. No existing behavior changes.

## Related Issues and PRs

See feature request here: #3062
