### PR TITLE
test: use multiline regex search helper

### DIFF
--- a/hydra/test_utils/test_utils.py
+++ b/hydra/test_utils/test_utils.py
@@ -334,7 +334,7 @@ if __name__ == "__main__":
                 f"Unexpected number of output lines from {task_file}, output lines:\n\n{file_str}"
             )
             for idx in range(len(output)):
-                assert_regex_match(expected_outputs[idx], output[idx])
+                assert_multiline_regex_search(expected_outputs[idx], output[idx])
         # some tests are parsing the file output for more specialized testing.
         return file_str
     finally:
@@ -427,33 +427,6 @@ def assert_text_same(
         print(diff)
         print("-------------------------------")
         assert False, "Mismatch between expected and actual text"
-
-
-def assert_regex_match(
-    from_line: str, to_line: str, from_name: str = "Expected", to_name: str = "Actual"
-) -> None:
-    """Check that the lines of `from_line` (which can be a regex expression)
-    matches the corresponding lines of `to_line` string.
-
-    In case the regex match fails, we display the diff as if `from_line` was a regular string.
-    """
-    normalized_from_line = [x for x in normalize_newlines(from_line).split("\n") if x]
-    normalized_to_line = [x for x in normalize_newlines(to_line).split("\n") if x]
-    if len(normalized_from_line) != len(normalized_to_line):
-        assert_text_same(
-            from_line=from_line,
-            to_line=to_line,
-            from_name=from_name,
-            to_name=to_name,
-        )
-    for line1, line2 in zip(normalized_from_line, normalized_to_line):
-        if line1 != line2 and re.match(line1, line2) is None:
-            assert_text_same(
-                from_line=from_line,
-                to_line=to_line,
-                from_name=from_name,
-                to_name=to_name,
-            )
 
 
 def assert_multiline_regex_search(

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -13,7 +13,7 @@ from pytest import mark, param
 
 from hydra.core.utils import JobReturn, JobStatus
 from hydra.test_utils.test_utils import (
-    assert_regex_match,
+    assert_multiline_regex_search,
     chdir_hydra_root,
     run_process,
     run_python_script,
@@ -101,7 +101,7 @@ def test_app_with_callbacks(
     cmd.extend(args)
     result, _err = run_python_script(cmd)
 
-    assert_regex_match(
+    assert_multiline_regex_search(
         from_line=expected,
         to_line=result,
         from_name="Expected output",

--- a/tests/test_examples/test_basic_sweep.py
+++ b/tests/test_examples/test_basic_sweep.py
@@ -6,7 +6,7 @@ from typing import List
 from pytest import mark
 
 from hydra.test_utils.test_utils import (
-    assert_regex_match,
+    assert_multiline_regex_search,
     chdir_hydra_root,
     run_python_script,
 )
@@ -72,7 +72,7 @@ def test_basic_sweep_example(
     cmd.extend(args)
     result, _err = run_python_script(cmd)
 
-    assert_regex_match(
+    assert_multiline_regex_search(
         from_line=expected,
         to_line=result,
         from_name="Expected output",

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -17,7 +17,6 @@ from hydra.test_utils.test_utils import (
     TSweepRunner,
     TTaskRunner,
     assert_multiline_regex_search,
-    assert_regex_match,
     assert_text_same,
     chdir_hydra_root,
     integration_test,
@@ -1601,7 +1600,7 @@ def test_hydra_main_without_config_path(tmpdir: Path) -> None:
         See https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path for more information.
           @hydra.main()
         """)
-    assert_regex_match(
+    assert_multiline_regex_search(
         from_line=expected,
         to_line=err,
         from_name="Expected error",
@@ -1621,7 +1620,7 @@ def test_job_chdir_not_specified(tmpdir: Path) -> None:
         See https://hydra.cc/docs/1.2/upgrades/1.1_to_1.2/changes_to_job_working_dir/ for more information..*
         .*
         """)
-    assert_regex_match(
+    assert_multiline_regex_search(
         from_line=expected,
         to_line=err,
         from_name="Expected error",
@@ -1929,7 +1928,7 @@ def test_hydra_mode(
     if error:
         expected = normalize_newlines(expected_output)
         ret = run_with_error(cmd)
-        assert_regex_match(
+        assert_multiline_regex_search(
             from_line=expected,
             to_line=ret,
             from_name="Expected output",
@@ -1937,14 +1936,14 @@ def test_hydra_mode(
         )
     elif warning:
         out, err = run_python_script(cmd, allow_warnings=True)
-        assert_regex_match(
+        assert_multiline_regex_search(
             from_line=expected_output,
             to_line=out,
             from_name="Expected output",
             to_name="Actual output",
         )
         assert warning_msg is not None
-        assert_regex_match(
+        assert_multiline_regex_search(
             from_line=warning_msg,
             to_line=err,
             from_name="Expected error",
@@ -1952,7 +1951,7 @@ def test_hydra_mode(
         )
     else:
         out, _ = run_python_script(cmd)
-        assert_regex_match(
+        assert_multiline_regex_search(
             from_line=expected_output,
             to_line=out,
             from_name="Expected output",
@@ -1978,7 +1977,7 @@ def test_hydra_runtime_choice_1882(tmpdir: Path) -> None:
                 nesterov""")
 
     out, _ = run_python_script(cmd)
-    assert_regex_match(
+    assert_multiline_regex_search(
         from_line=expected_output,
         to_line=out,
         from_name="Expected output",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,6 @@ from hydra.core.override_parser.overrides_parser import OverridesParser
 from hydra.errors import HydraDeprecationError
 from hydra.test_utils.test_utils import (
     assert_multiline_regex_search,
-    assert_regex_match,
 )
 
 
@@ -345,7 +344,7 @@ class TestRunAndReport:
                 run_and_report(demo_func)
         mock_stderr.seek(0)
         stderr_output = mock_stderr.read()
-        assert_regex_match(expected_traceback_regex, stderr_output)
+        assert_multiline_regex_search(expected_traceback_regex, stderr_output)
 
     def test_simplified_traceback_failure(self) -> None:
         """
@@ -373,4 +372,4 @@ class TestRunAndReport:
                 run_and_report(demo_func)
         mock_stderr.seek(0)
         stderr_output = mock_stderr.read()
-        assert_regex_match(expected_traceback_regex, stderr_output)
+        assert_multiline_regex_search(expected_traceback_regex, stderr_output)


### PR DESCRIPTION
## Change

- migrate the remaining test call sites from per-line `assert_regex_match` to
  `assert_multiline_regex_search`
- remove the obsolete helper and its line-count/zip implementation

## Why

The old helper split both values and ran a separate `re.match` for every line,
which prevented patterns from expressing multiline context and duplicated the
existing multiline search helper. A single normalized `re.search(...,
re.MULTILINE)` now handles these assertions consistently.

## Checks

- Python byte-compilation passed for all changed modules
- `git diff --check`

The focused pytest suite could not start locally because this source checkout
does not contain generated ANTLR parsers and the machine has no Java runtime.
CI's normal parser-generation step remains the authoritative full-suite check.

Fixes #1749
