### PR TITLE
fix(optuna-sweeper): pass values=None when marking trial as FAIL, add NaN check

### DIFF
--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import functools
 import logging
+import math
 import sys
 import warnings
 from textwrap import dedent
@@ -386,6 +387,11 @@ class OptunaSweeperImpl(Sweeper):
                                 f" mismatched. Expect {len(directions)}, but actually {len(values)}."
                             )
 
+                    if values is not None and any(math.isnan(v) for v in values):
+                        raise ValueError(
+                            f"Return value must not be NaN. Got '{ret.return_value}'."
+                        )
+
                     try:
                         study.tell(trial=trial, state=state, values=values)
                     except RuntimeError as e:
@@ -400,7 +406,7 @@ class OptunaSweeperImpl(Sweeper):
 
                 except Exception as e:
                     state = optuna.trial.TrialState.FAIL
-                    study.tell(trial=trial, state=state, values=values)
+                    study.tell(trial=trial, state=state, values=None)
                     log.warning(f"Failed experiment: {e}")
                     failures.append(e)
 

--- a/plugins/hydra_optuna_sweeper/news/2237.bugfix
+++ b/plugins/hydra_optuna_sweeper/news/2237.bugfix
@@ -1,0 +1,1 @@
+Fix a crash in the Optuna sweeper when a trial's objective value is NaN, by reporting the trial as FAILed instead of raising a secondary error from Optuna.


### PR DESCRIPTION
## Problem

Closes #2237

When a Hydra run returns NaN objective values (e.g. a diverged model), the Optuna sweeper crashes with a double exception:

1. `study.tell(state=COMPLETE, values=[nan])` raises `ValueError: Trial N failed, because the objective function returned nan.`
2. The `except Exception` handler sets `state = TrialState.FAIL` but still passes the original `values` to a second `study.tell` call, which raises another `ValueError: Values cannot be specified when state is TrialState.PRUNED or TrialState.FAIL.`

This second exception is **unhandled** and crashes the entire sweep.

## Fix

Two-part change in `plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py`:

**1. Proactive NaN check** — after computing `values`, raise a descriptive `ValueError` if any value is NaN, so the failure is captured cleanly by the existing `except` block with a readable warning message.

**2. Fix the except block** — change `study.tell(trial=trial, state=state, values=values)` to `study.tell(trial=trial, state=state, values=None)`. Optuna's API requires `values=None` when state is `FAIL` or `PRUNED`; passing the NaN values caused the secondary crash.

## Behaviour after fix

A trial that returns NaN objective values is recorded as `FAIL` in the Optuna study (consistent with a diverged run), a warning is logged, and the sweep continues to the next trial instead of crashing.