### PR TITLE
Treat a call-site ??? as a literal value

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -618,8 +618,10 @@ def _get_effective_control(
 def _is_missing_parameter(
     node: Any, overrides: Optional[ConfigOverlay], key: str
 ) -> bool:
+    # A call-site argument is a runtime value, so "???" is a plain string
+    # rather than a missing marker.
     if overrides is not None and key in overrides:
-        return isinstance(overrides[key], str) and overrides[key] == "???"
+        return False
     return OmegaConf.is_missing(node, key)
 
 

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -205,10 +205,11 @@ def register_test_resolver(name: str, value: Any) -> Any:
             partial(AClass, a=10, b=20, c=30),
             id="class+override+partial1",
         ),
+        # "???" passed at the call-site is a literal string, not a missing value
         param(
             {"_target_": "tests.instantiate.AClass", "b": 20, "c": 30},
             {"a": "???", "_partial_": True},
-            partial(AClass, b=20, c=30),
+            partial(AClass, a="???", b=20, c=30),
             id="class+override+partial1+missing",
         ),
         param(
@@ -465,6 +466,33 @@ def test_partial_with_missing(instantiate_func: Any) -> Any:
     obj = partial_obj(a=10)
     assert partial_equal(obj, AClass(a=10, b=20, c=30))
     assert str(config) == original_config_str
+
+
+def test_callsite_missing_string_is_literal(instantiate_func: Any) -> Any:
+    """
+    A call-site argument is a runtime value, so "???" is passed to the target
+    as a string instead of being read as an OmegaConf missing marker.
+    """
+    result = instantiate_func(
+        {"_target_": "tests.instantiate.ArgsClass"},
+        value="???",
+    )
+
+    assert result.kwargs == {"value": "???"}
+
+
+def test_partial_callsite_missing_string_is_literal(instantiate_func: Any) -> Any:
+    """
+    In 3354, partial instantiation read a call-site "???" as a missing value
+    and silently omitted the argument.
+    """
+    factory = instantiate_func(
+        {"_target_": "tests.instantiate.ArgsClass"},
+        value="???",
+        _partial_=True,
+    )
+
+    assert factory().kwargs == {"value": "???"}
 
 
 def test_instantiate_with_missing(instantiate_func: Any) -> Any:


### PR DESCRIPTION
## Motivation

Fixes #3354.

Call-site arguments are runtime values in Hydra 1.4, but partial instantiation still read an
argument equal to `"???"` as an OmegaConf missing marker and silently omitted it:

```python
cfg = {"_target_": "builtins.dict"}

instantiate(cfg, value="???")                    # {'value': '???'} — already correct
instantiate(cfg, value="???", _partial_=True)()  # {} — should be {'value': '???'}
```

Confirmed on `main` at `6978bcf593`.

`_is_missing_parameter()` returned `True` for a call-site override equal to `"???"`, which
retained behavior from when call-site arguments were merged into an OmegaConf
configuration. Its only call site is the `is_partial` branch in `instantiate_node`, which
is why normal instantiation was already correct and only partial instantiation dropped the
argument. A call-site argument is never missing, so that branch now returns `False`.

`???` originating in the configuration is unchanged: it still raises
`MissingMandatoryValue` on normal instantiation, and still stays unbound during partial
instantiation. `test_instantiate_with_missing` and `test_partial_with_missing` both pass
unmodified.

### One existing expectation changed

`test_class_instantiate[class+override+partial1+missing]` passed `{"a": "???", "_partial_":
True}` and expected `partial(AClass, b=20, c=30)`, with `a` dropped. That parametrization
is the behavior this issue asks to remove, so it now expects `partial(AClass, a="???",
b=20, c=30)`.

### On the news fragment

I did not add one, since the regression exists only on the unreleased 1.4 development line
and nothing changes for anyone on a shipped release — the 1.4 call-site model is already
described by `3216.api_change`. This follows #3302, #3310, #3316 and #3325, which made
comparable development-line instantiate corrections without a fragment. Happy to add one if
you would rather have it.

No documentation change either: nothing under `website/docs/` described the previous
call-site `???` behavior.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes.

### For non-trivial features, API changes, or behavior changes: is there an issue or design discussion where maintainers agreed on the direction?

Yes — #3354 specifies both the expected behavior and the scope ("Remove the call-site
override special case from missing-parameter detection and add coverage for both normal and
partial instantiation"). This PR implements exactly that and nothing more.

## Test Plan

No special setup beyond a normal core checkout.

Two new tests in `tests/instantiate/test_instantiate.py`, placed next to
`test_partial_with_missing`, their configured-`???` counterpart:

- `test_partial_callsite_missing_string_is_literal` — the regression. Confirmed failing
  before the change with `assert {} == {'value': '???'}`.
- `test_callsite_missing_string_is_literal` — the normal-instantiation half, which was
  already correct; included per the coverage scope in the issue.

```
pytest tests/instantiate/                  # 483 passed (481 before + 2 new)
pytest --ignore=tests/test_completion.py   # 2162 passed, 0 failed
```

Both assertions in the issue body were also run directly and pass.

`tests/test_completion.py` has 130 failures in my environment (macOS zsh/bash shell
integration). They are unrelated: the list of failing test ids is identical to the one
pristine `main` produces here.

Lint clean: `ruff format --check .`, `ruff check .`, `yamllint --strict .`,
`bandit -ll -r .`. `pyrefly check --config pyproject.toml` reports one error in
`build_helpers/build_helpers.py`, which is untouched here and reports identically on
pristine `main`.

## Related Issues and PRs

- Fixes #3354
- Sibling regression #3353 is not addressed here.
- Independent of #3352, per the scope note in #3353. Both touch
  `hydra/_internal/instantiate/_instantiate2.py` but different functions
  (`_is_missing_parameter` here, `_instantiate_effective_value` there), so they should not
  conflict meaningfully in either merge order.
