### PR TITLE
Resolve instantiate interpolations against call-site overrides

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -1,8 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import copy
 import functools
 import inspect
 import os
+import re
 from contextvars import ContextVar
 from enum import Enum
 from textwrap import dedent
@@ -102,6 +104,13 @@ ConfigOverlay = Union[Dict[str, Any], DictConfig]
 _TARGET_WHITELIST_CONTEXT: ContextVar[NormalizedTargetWhitelist] = ContextVar(
     "hydra_instantiate_target_whitelist", default=None
 )
+_INSTANTIATE_OVERRIDE_RESOLVER = "hydra.instantiate_override"
+_INSTANTIATE_OVERRIDE_STORAGE = "_hydra_instantiate_overrides"
+
+
+def _resolve_instantiate_override(token: str, *, _root_: Any) -> Any:
+    source, key = _root_.__dict__[_INSTANTIATE_OVERRIDE_STORAGE][token]
+    return source[key]
 
 
 def _get_os_alias_target(target: str) -> str:
@@ -509,6 +518,13 @@ def instantiate(
         config = OmegaConf.structured(config, flags={"allow_objects": True})
 
     if OmegaConf.is_dict(config):
+        resolution_overrides = dict(kwargs)
+        if args:
+            resolution_overrides[_Keys.ARGS] = args
+        if resolution_overrides:
+            config = _copy_config_with_override_interpolations(
+                config, resolution_overrides
+            )
         return instantiate_node(
             config,
             *args,
@@ -739,6 +755,178 @@ def _get_dict_override_merge_base(
     ):
         return configured_value
     return None
+
+
+def _get_override_child(source: Any, key: Any) -> Any:
+    if isinstance(source, DictConfig):
+        return source._get_node(key, validate_access=False)
+    if OmegaConf.is_sequence(source):
+        return source._get_node(key)
+    return source[key]
+
+
+def _replace_child(parent: Any, key: Any, child: Any) -> None:
+    child._set_parent(parent)
+    child._set_key(key)
+    parent.__dict__["_content"][key] = child
+
+
+def _override_mapping(value: Any) -> Optional[ConfigOverlay]:
+    if OmegaConf.is_config(value) and (
+        value._is_none() or value._is_missing() or value._is_interpolation()
+    ):
+        return None
+    return _get_dict_override(value)
+
+
+def _create_override_node(
+    value: Any,
+    *,
+    source: Any,
+    key: Any,
+    path: Tuple[Any, ...],
+    storage: Dict[str, Tuple[Any, Any]],
+) -> Any:
+    mapping = _override_mapping(value)
+    if mapping is not None:
+        result = OmegaConf.create({}, flags={"allow_objects": True})
+        for child_key in mapping:
+            child = _create_override_node(
+                _get_override_child(mapping, child_key),
+                source=mapping,
+                key=child_key,
+                path=(*path, child_key),
+                storage=storage,
+            )
+            _replace_child(result, child_key, child)
+        return result
+
+    if not is_structured_config(value) and (
+        isinstance(value, (list, tuple)) or OmegaConf.is_sequence(value)
+    ):
+        is_tuple = type(value) is tuple or OmegaConf.is_tuple(value)
+        result = OmegaConf.create(() if is_tuple else [])
+        content = []
+        for index in range(len(value)):
+            child = _create_override_node(
+                _get_override_child(value, index),
+                source=value,
+                key=index,
+                path=(*path, index),
+                storage=storage,
+            )
+            child._set_parent(result)
+            child._set_key(index)
+            content.append(child)
+        result.__dict__["_content"] = content
+        return result
+
+    name = re.sub(r"[^A-Za-z0-9_]+", "_", ".".join(map(str, path))).strip("_")
+    name = name or "value"
+    if name[0].isdigit() or name.lower() in {"false", "inf", "nan", "null", "true"}:
+        name = f"value_{name}"
+    token = name
+    index = 2
+    while token in storage:
+        token = f"{name}_{index}"
+        index += 1
+    storage[token] = (source, key)
+    return AnyNode(
+        f"${{{_INSTANTIATE_OVERRIDE_RESOLVER}:{token}}}",
+        flags={"allow_objects": True},
+    )
+
+
+def _apply_override_interpolations(
+    node: DictConfig,
+    overrides: ConfigOverlay,
+    storage: Dict[str, Tuple[Any, Any]],
+    *,
+    is_target_parameter: bool,
+) -> None:
+    configured_values = {}
+    override_nodes = {}
+    for key in overrides:
+        configured_values[key] = node._get_node(key, validate_access=False)
+        override = _get_override_child(overrides, key)
+        override_nodes[key] = _create_override_node(
+            override,
+            source=overrides,
+            key=key,
+            path=(key,),
+            storage=storage,
+        )
+        _replace_child(node, key, override_nodes[key])
+
+    mapping_keys = [
+        key
+        for key in overrides
+        if configured_values[key] is not None
+        and _override_mapping(_get_override_child(overrides, key)) is not None
+    ]
+    # Each pass lets another interpolation level observe effective overrides.
+    for _ in mapping_keys:
+        for key in mapping_keys:
+            current_value = node._get_node(key, validate_access=False)
+            _replace_child(node, key, configured_values[key])
+            try:
+                merge_base = _get_dict_override_merge_base(
+                    node, key, is_target_parameter=is_target_parameter
+                )
+            finally:
+                _replace_child(node, key, current_value)
+
+            if merge_base is not None:
+                merged = OmegaConf.merge(merge_base, override_nodes[key])
+                _replace_child(node, key, merged)
+
+
+def _copy_config_with_override_interpolations(
+    config: DictConfig, overrides: ConfigOverlay
+) -> DictConfig:
+    OmegaConf.register_resolver(
+        _INSTANTIATE_OVERRIDE_RESOLVER,
+        _resolve_instantiate_override,
+        replace=True,
+        annotation_validation="off",
+    )
+
+    path = []
+    current: Any = config
+    while current._get_parent() is not None:
+        path.append(current._key())
+        current = current._get_parent()
+
+    copied_root = copy.deepcopy(current)
+    copied_config = copied_root
+    for key in reversed(path):
+        copied_config = _get_override_child(copied_config, key)
+
+    if copied_config._is_none():
+        ref_type = copied_config._metadata.ref_type
+        parent = copied_config._get_parent()
+        key = copied_config._key()
+        copied_config = (
+            OmegaConf.structured(ref_type)
+            if is_structured_config(ref_type)
+            else OmegaConf.create({})
+        )
+        if parent is None:
+            copied_root = copied_config
+        else:
+            _replace_child(parent, key, copied_config)
+
+    storage: Dict[str, Tuple[Any, Any]] = dict(
+        current.__dict__.get(_INSTANTIATE_OVERRIDE_STORAGE, {})
+    )
+    copied_root.__dict__[_INSTANTIATE_OVERRIDE_STORAGE] = storage
+    _apply_override_interpolations(
+        copied_config,
+        overrides,
+        storage,
+        is_target_parameter=_Keys.TARGET in overrides or _is_target(copied_config),
+    )
+    return copied_config
 
 
 def _instantiate_effective_value(

--- a/news/2350.api_change
+++ b/news/2350.api_change
@@ -1,3 +1,3 @@
 A `dict` or `DictConfig` call-site argument to `hydra.utils.instantiate()` now
-replaces a plain, non-target mapping configured for a target parameter instead
-of merging into it.
+replaces a configured plain, non-target mapping passed to a target instead of
+merging into it.

--- a/news/3216.api_change
+++ b/news/3216.api_change
@@ -1,14 +1,7 @@
-`hydra.utils.instantiate()` no longer eagerly resolves the entire configuration
-tree. Interpolations are now resolved as recursive traversal needs them.
-With `_recursive_=False` and the default `_convert_="none"`, Hydra no longer
-makes a final copy of OmegaConf containers before the target call. Containers
-passed through from the input tree retain their identity, lazy interpolations,
-ancestor context, resolver cache, and inherited flags.
-Applications that rely on eager resolution must call `OmegaConf.resolve(config)`
-before `instantiate(config)`. Mutations made by a target to such a Config
-container now affect the original configuration. Constructors or other called
-code that mutate inherited `readonly` or `struct` containers may also raise
-`ReadonlyConfigError` or `ConfigKeyError`; use OmegaConf's `read_write()` or
-`open_dict()` context managers around intentional mutations. See the
+`hydra.utils.instantiate()` now resolves configured interpolations as recursive
+traversal reaches them instead of resolving the entire input configuration up
+front. With `_recursive_=False`, `_convert_="none"`, and no call-site overrides,
+configured OmegaConf containers passed as target arguments retain their
+identity, so mutations to them affect the input configuration. See the
 [Hydra 1.4 instantiate migration guide](https://hydra.cc/docs/upgrades/1.3_to_1.4/instantiate_resolution/)
-for creating an independent Config copy.
+for details.

--- a/news/3216.feature
+++ b/news/3216.feature
@@ -1,2 +1,3 @@
-`hydra.utils.instantiate()` no longer copies the entire configuration tree,
-making instantiation 4 to 10 times faster in benchmarks.
+`hydra.utils.instantiate()` calls on OmegaConf inputs without call-site
+overrides no longer make an additional full-tree copy. Benchmarked calls run 4
+to 10 times faster.

--- a/news/3356.bugfix
+++ b/news/3356.bugfix
@@ -1,0 +1,3 @@
+Make configured interpolations in `hydra.utils.instantiate()` resolve against
+the complete set of call-site overrides without modifying the input
+configuration.

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -225,13 +225,13 @@ def register_test_resolver(name: str, value: Any) -> Any:
         param(
             {"_target_": "tests.instantiate.AClass", "b": 200, "c": "${b}"},
             {"a": 10, "b": 99, "d": 40},
-            AClass(10, 99, 200, 40),
+            AClass(10, 99, 99, 40),
             id="class+override+interpolation",
         ),
         param(
             {"_target_": "tests.instantiate.AClass", "b": 200, "c": "${b}"},
             {"a": 10, "b": 99, "_partial_": True},
-            partial(AClass, a=10, b=99, c=200),
+            partial(AClass, a=10, b=99, c=99),
             id="class+override+interpolation+partial1",
         ),
         param(
@@ -242,7 +242,7 @@ def register_test_resolver(name: str, value: Any) -> Any:
                 "c": "${b}",
             },
             {"a": 10, "b": 99},
-            partial(AClass, a=10, b=99, c=200),
+            partial(AClass, a=10, b=99, c=99),
             id="class+override+interpolation+partial2",
         ),
         # Check class and static methods
@@ -452,6 +452,151 @@ def test_class_instantiate(
     assert str(config) == original_config_str
 
 
+def test_callsite_override_is_visible_to_configured_interpolation(
+    instantiate_func: Any,
+) -> None:
+    config = {
+        "_target_": "tests.instantiate.ArgsClass",
+        "base": 10,
+        "middle": "${base}",
+        "derived": "${middle}",
+    }
+
+    result = instantiate_func(config, base=20)
+
+    assert result.kwargs == {"base": 20, "middle": 20, "derived": 20}
+
+
+def test_callsite_override_is_visible_through_absolute_interpolation(
+    instantiate_func: Any,
+) -> None:
+    config = OmegaConf.create(
+        {
+            "node": {
+                "_target_": "tests.instantiate.ArgsClass",
+                "base": 10,
+                "derived": "${node.base}",
+            }
+        }
+    )
+
+    result = instantiate_func(config.node, base=20)
+
+    assert result.kwargs == {"base": 20, "derived": 20}
+    assert config.node.base == 10
+
+
+@mark.parametrize("base", ["${literal}", "before ${literal} after"])
+def test_callsite_override_remains_literal_when_referenced_by_config(
+    instantiate_func: Any, base: str
+) -> None:
+    result = instantiate_func(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "base": "configured",
+            "derived": "${base}",
+        },
+        base=base,
+    )
+
+    assert result.kwargs == {"base": base, "derived": base}
+
+
+def test_callsite_runtime_object_is_visible_to_configured_interpolation(
+    instantiate_func: Any,
+) -> None:
+    base = Parameters([1, 2, 3])
+
+    result = instantiate_func(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "base": "configured",
+            "derived": "${base}",
+        },
+        base=base,
+    )
+
+    assert result.kwargs["base"] is base
+    assert result.kwargs["derived"] is base
+
+
+def test_callsite_override_storage_survives_nested_reinstantiation(
+    instantiate_func: Any,
+) -> None:
+    config = OmegaConf.create(
+        {
+            "_target_": "builtins.dict",
+            "_recursive_": False,
+            "base": 10,
+            "child": {
+                "_target_": "builtins.dict",
+                "value": "${..base}",
+            },
+        }
+    )
+
+    result = instantiate_func(config, base=20)
+    child = result["child"]
+
+    assert child.value == 20
+    assert instantiate_func(child, extra=1) == {"value": 20, "extra": 1}
+    assert config.base == 10
+
+
+def test_callsite_override_resolver_token_uses_normalized_path() -> None:
+    config = OmegaConf.create(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "base": {"value": 10},
+        }
+    )
+
+    copied = _instantiate2._copy_config_with_override_interpolations(
+        config, {"base": {"value": 20}}
+    )
+
+    assert copied.base._get_node("value")._value() == (
+        "${hydra.instantiate_override:base_value}"
+    )
+
+
+@mark.parametrize(
+    ("key", "token"),
+    [
+        param("123", "value_123", id="integer"),
+        param("true", "value_true", id="boolean"),
+        param("nan", "value_nan", id="float"),
+    ],
+)
+def test_callsite_override_resolver_token_is_not_parsed_as_primitive(
+    key: str, token: str
+) -> None:
+    config = OmegaConf.create({key: 10})
+
+    copied = _instantiate2._copy_config_with_override_interpolations(config, {key: 20})
+
+    node = copied._get_node(key)
+    assert node is not None
+    assert node._value() == f"${{hydra.instantiate_override:{token}}}"
+    assert copied[key] == 20
+
+
+def test_callsite_override_restores_internal_resolver_after_clear() -> None:
+    OmegaConf.clear_resolver(_instantiate2._INSTANTIATE_OVERRIDE_RESOLVER)
+
+    result = _instantiate2.instantiate(
+        {
+            "_target_": "builtins.dict",
+            "base": 10,
+            "derived": "${base}",
+        },
+        base=20,
+        _target_whitelist_=UNSAFE_ALLOW_ALL_TARGETS,
+    )
+
+    assert result == {"base": 20, "derived": 20}
+
+
 def test_partial_with_missing(instantiate_func: Any) -> Any:
     config = {
         "_target_": "tests.instantiate.AClass",
@@ -510,6 +655,15 @@ def test_none_cases(
     assert ret.kwargs["list"][1] is None
     assert ret.kwargs["list"][2] is None
     assert str(cfg) == original_config_str
+
+
+def test_callsite_override_materializes_none_root(instantiate_func: Any) -> None:
+    config = DictConfig(None)
+
+    result = instantiate_func(config, value=10)
+
+    assert result == {"value": 10}
+    assert config._is_none()
 
 
 @mark.parametrize("convert_to_list", [True, False])
@@ -669,7 +823,7 @@ def test_instantiate_does_not_copy_unrelated_root_siblings(
         flags={"allow_objects": True},
     )
 
-    assert instantiate_func(cfg.node) == AClass(a=10, b=20, c=30)
+    assert instantiate_func(cfg.node, b=99) == AClass(a=10, b=99, c=30)
 
 
 def test_non_recursive_config_argument_is_passed_directly_without_resolving(
@@ -1208,6 +1362,43 @@ def test_dict_override_merges_interpolated_configured_target(
     assert result.kwargs["value"] == Tree(value=20, left=Tree(value=30))
 
 
+@mark.parametrize(
+    "overrides",
+    [
+        param(
+            {
+                "value": {"runtime": 20},
+                "template": {"configured": 10},
+            },
+            id="dependent-first",
+        ),
+        param(
+            {
+                "template": {"configured": 10},
+                "value": {"runtime": 20},
+            },
+            id="dependency-first",
+        ),
+    ],
+)
+def test_dict_override_merge_is_independent_of_callsite_argument_order(
+    instantiate_func: Any, overrides: Dict[str, Any]
+) -> None:
+    result = instantiate_func(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "template": {"_target_": "builtins.dict", "original": 0},
+            "value": "${template}",
+        },
+        **overrides,
+    )
+
+    assert result.kwargs == {
+        "template": {"original": 0, "configured": 10},
+        "value": {"original": 0, "configured": 10, "runtime": 20},
+    }
+
+
 def test_dict_override_merges_interpolated_structured_config(
     instantiate_func: Any,
 ) -> None:
@@ -1555,8 +1746,9 @@ def test_runtime_override_is_not_coerced_by_structured_config(
     assert result.lr == "runtime value"
 
 
+@mark.parametrize("with_override", [False, True])
 def test_nested_target_can_register_resolver_for_later_argument(
-    instantiate_func: Any,
+    instantiate_func: Any, with_override: bool
 ) -> None:
     resolver_name = "hydra_instantiate_delayed_resolution"
     OmegaConf.clear_resolver(resolver_name)
@@ -1572,12 +1764,16 @@ def test_nested_target_can_register_resolver_for_later_argument(
                     "value": 10,
                 },
                 "second": f"${{{resolver_name}:}}",
-            }
+            },
+            **({"callsite": 20} if with_override else {}),
         )
     finally:
         OmegaConf.clear_resolver(resolver_name)
 
-    assert result.kwargs == {"first": 10, "second": 10}
+    expected = {"first": 10, "second": 10}
+    if with_override:
+        expected["callsite"] = 20
+    assert result.kwargs == expected
 
 
 @mark.parametrize(

--- a/tests/instantiate/test_positional.py
+++ b/tests/instantiate/test_positional.py
@@ -132,6 +132,17 @@ def test_instantiate_args_kwargs_with_interpolation(cfg: Any, expected: Any) -> 
             id="direct_args",
         ),
         param(
+            {
+                "_target_": "tests.instantiate.ArgsClass",
+                "_args_": [1],
+                "derived": "${._args_.0}",
+            },
+            [2],
+            {},
+            ArgsClass(2, derived=2),
+            id="direct_args+interpolation",
+        ),
+        param(
             {"_target_": "tests.instantiate.ArgsClass", "_args_": [1]},
             [],
             {"_args_": [2]},

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -157,15 +157,18 @@ component = instantiate(
 **Named arguments** : Config fields (except reserved fields like `_target_`) are passed as named arguments to the target.
 Named arguments in the config can be overridden by passing named argument with the same name in the `instantiate()` call-site.
 
-Call-site arguments are applied separately from the input configuration. They
-replace the corresponding arguments passed to the target without modifying the
-input configuration. Ordinary replacements therefore do not affect how its
-interpolations resolve. Call-site values are also not generally coerced against
-Structured Config fields. Dictionary overrides of Structured Config nodes are
-the exception, as described below. Configuration values are resolved lazily as
-instantiation proceeds instead of resolving and copying the full configuration
-tree up front. This avoids processing unrelated configuration values and allows
-runtime state established by an earlier target to be used while resolving a
+Call-site arguments replace the corresponding arguments passed to the target
+without modifying the input configuration. Interpolations in other configured
+arguments resolve against those call-site values. Call-site values are not
+generally coerced against Structured Config fields. Dictionary overrides of
+Structured Config nodes are the exception, as described below.
+
+Configuration values are resolved lazily as instantiation proceeds instead of
+resolving the full configuration tree up front. Calls on OmegaConf inputs
+without call-site overrides do not make an additional input copy. When
+overrides are present, Hydra uses a private copy so configured interpolations
+resolve against the call-site values while leaving the input unchanged. Runtime
+state established by an earlier target can still be used while resolving a
 later argument.
 
 Primitive values, native `list`, `tuple`, and `dict` containers, and OmegaConf

--- a/website/docs/upgrades/1.3_to_1.4/breaking_changes.md
+++ b/website/docs/upgrades/1.3_to_1.4/breaking_changes.md
@@ -68,8 +68,8 @@ have been removed:
   Structured Configs.
 - `hydra.utils.instantiate()` resolves interpolations during recursive
   traversal instead of resolving the entire configuration before
-  instantiation. With `_recursive_=False` and `_convert_="none"`, Config
-  containers are passed through without a final copy. See
+  instantiation. With `_recursive_=False`, `_convert_="none"`, and no call-site
+  overrides, Config containers are passed through without a final copy. See
   [Instantiate resolution and call-site overrides](/docs/upgrades/1.3_to_1.4/instantiate_resolution).
 - Launcher and sweeper plugin configurations are instantiated
   non-recursively.

--- a/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
+++ b/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
@@ -13,30 +13,32 @@ for the associated security and migration context.
 
 ## Benefits
 
-`instantiate()` no longer deep-copies and eagerly resolves the full input
-configuration before it starts instantiating targets. Instead, it traverses the
-configuration and resolves each value when that value is needed.
+`instantiate()` no longer eagerly resolves the full input configuration before
+it starts instantiating targets. Instead, it traverses the configuration and
+resolves each value when that value is needed. Calls on OmegaConf inputs without
+call-site overrides also avoid the former additional full-tree copy. When
+overrides are present, Hydra uses a private copy so configured interpolations
+resolve against the call-site values without modifying the input configuration.
 
 This has several benefits:
 
-- Unrelated parts of the configuration tree are not copied or resolved.
+- Unrelated parts of the configuration tree are not resolved.
 - A call-site argument can replace an unresolvable configured value without
   forcing Hydra to resolve the replaced value first.
 - An earlier target can establish runtime state, such as registering a custom
   resolver, before a later argument is resolved.
-- With `_recursive_=False` and the default `_convert_="none"`, Hydra no longer
-  makes a final copy of OmegaConf containers before the target call. Containers
-  passed through from the input tree retain their identity, lazy
-  interpolations, ancestor context, resolver cache, and inherited flags.
+- With `_recursive_=False`, the default `_convert_="none"`, and no call-site
+  overrides, Hydra no longer makes a final copy of OmegaConf containers before
+  the target call. Containers passed through from the input tree retain their
+  identity, lazy interpolations, ancestor context, resolver cache, and inherited
+  flags.
 
 ## Compatibility impact
 
-Call-site arguments are now a separate runtime overlay. They determine the
-arguments passed to the target, but they do not modify the input configuration
-itself. Ordinary replacements do not affect how input interpolations resolve.
-A dictionary overriding a Structured Config node is the exception: Hydra
-updates a copy of that node, so its interpolations resolve against the updated
-values.
+Call-site arguments determine the arguments passed to the target, but they do
+not modify the input configuration itself. Hydra applies them to a private copy
+used for resolution, so interpolations in other configured arguments resolve
+against the effective values.
 
 Call-site arguments are not generally coerced or validated against the
 corresponding field in an input Structured Config. Dictionary overrides of
@@ -52,7 +54,7 @@ value:
 - If the configured value is a Structured Config node, Hydra validates the
   merged dictionary against the schema. Fields that the dictionary does not
   name retain their configured values, and interpolations within the node can
-  observe the merged values.
+  resolve against the merged values.
 - Otherwise, if the configured mapping contains `_target_`, Hydra merges the
   dictionary into that target config, preserving its target, instantiation
   settings, and arguments that the dictionary does not name. `_recursive_`
@@ -158,21 +160,22 @@ cfg = OmegaConf.create(
 )
 
 result = instantiate(cfg, b=99, _target_whitelist_="builtins.dict")
-assert result == {"b": 99, "c": 200}
+assert result == {"b": 99, "c": 99}
 ```
 
-Hydra 1.3 merged `b=99` into a copied configuration before resolving `${b}`,
-so `c` also became `99`. Hydra 1.4 leaves `cfg` unchanged, resolves `${b}`
-against the original configuration, and independently passes the call-site
-value `b=99` to the target.
+Hydra 1.4 leaves `cfg` unchanged while resolving `${b}` against the effective
+call-site value. This preserves the result produced by Hydra 1.3 without
+eagerly resolving the full configuration.
 
-With `_recursive_=False` and `_convert_="none"`, OmegaConf containers are also
-no longer copied and detached before the target call. The target receives the
-same `DictConfig`, `ListConfig`, or `TupleConfig` object from the input tree.
-Mutations made by the target are therefore visible through the original
-configuration, and an attached subtree retains its ancestor configuration when
-stored or serialized. Other conversion modes retain their documented
-conversion behavior.
+With `_recursive_=False`, `_convert_="none"`, and no call-site overrides,
+OmegaConf containers are no longer copied and detached before the target call.
+The target receives the same `DictConfig`, `ListConfig`, or `TupleConfig`
+object from the input tree. Mutations made by the target are therefore visible
+through the original configuration, and an attached subtree retains its
+ancestor configuration when stored or serialized. When call-site overrides
+are present, configured containers come from Hydra's private resolution copy.
+Containers supplied directly as call-site values still retain their identity.
+Other conversion modes retain their documented conversion behavior.
 
 To pass an independent Config object instead, create one explicitly:
 
@@ -200,17 +203,5 @@ while copying:
 ```python
 independent = OmegaConf.create(
     OmegaConf.to_container(cfg.payload, resolve=True)
-)
-```
-
-If another argument should use the call-site value, pass that argument
-explicitly as well:
-
-```python
-result = instantiate(
-    cfg,
-    b=99,
-    c=99,
-    _target_whitelist_="builtins.dict",
 )
 ```


### PR DESCRIPTION
Apply call-site overrides to a private copy of the OmegaConf root and expose runtime values through an internal resolver. Configured interpolations therefore resolve against effective call-site values without modifying the input configuration or interpreting interpolation-like runtime strings.

Preserve mapping replacement, Structured Config validation, configured-target merging, lazy resolution, and runtime object identity. Cover named and positional overrides, relative, absolute, and chained interpolations, partial instantiation, null roots, and nested re-instantiation.

Update the documentation and news fragments to distinguish the no-override, no-copy path from the private-copy path used when call-site overrides are present.

Fixes #3353