### PR TITLE
Stop advertising HYDRA_FULL_ERROR in user-facing errors

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -468,7 +468,7 @@ def _resolve_target(
             try:
                 target = _locate(target)
             except Exception as e:
-                msg = f"Error locating target '{target}', set env var HYDRA_FULL_ERROR=1 to see chained exception."
+                msg = f"Error locating target '{target}'"
                 raise InstantiationException(_with_full_key(msg, full_key)) from e
     if not callable(target):
         msg = f"Expected a callable target, got '{target}' of type '{type(target).__name__}'"

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -283,9 +283,6 @@ def run_and_report(func: Any) -> Any:
                             exception_hook(type(ex), ex, final_tb)
                         except Exception:
                             traceback.print_exception(None, value=ex, tb=final_tb)
-                sys.stderr.write(
-                    "\nSet the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.\n"
-                )
             except Exception as ex2:
                 sys.stderr.write(
                     "An error occurred during Hydra's exception formatting:"

--- a/news/3329.api_change
+++ b/news/3329.api_change
@@ -1,0 +1,3 @@
+Hydra no longer suggests `HYDRA_FULL_ERROR=1` after a sanitized error. The variable still
+disables traceback sanitization and is now documented in the developer guide as a framework
+debugging facility.

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -2710,7 +2710,7 @@ def test_cannot_locate_target(instantiate_func: Any) -> None:
         InstantiationException,
         match=re.escape(
             dedent("""\
-                Error locating target 'not_found', set env var HYDRA_FULL_ERROR=1 to see chained exception.
+                Error locating target 'not_found'
                 full_key: foo""")
         ),
     ) as exc_info:

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -97,8 +97,6 @@ def test_partial_failure(
             val = 1 / cfg\.divisor(
                   ~~\^~~~~~~~~~~~~)?
         ZeroDivisionError: division by zero
-
-        Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.
         """).strip()
 
     assert_multiline_regex_search(expected_err_regex, err)

--- a/tests/test_examples/test_patterns.py
+++ b/tests/test_examples/test_patterns.py
@@ -49,8 +49,6 @@ def test_write_protect_config_node(tmpdir: Any) -> None:
         Cannot change read-only config container
             full_key: data_bits
             object_type=SerialPort
-
-        Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
         """)
     err = run_with_error(cmd)
     assert_text_same(from_line=expected, to_line=err)

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1285,8 +1285,7 @@ def test_module_run(
                 1\. To use it as a list, use key=\[value1,value2\]
                 2\. To use it as string, quote the value: key=\\'value1,value2\\'
                 3\. To sweep over it, add --multirun to your command line
-
-                Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\."""
+                """
             ).strip(),
             id="run:choice_sweep",
         ),
@@ -1299,8 +1298,7 @@ def test_module_run(
                 Value '\[1, 2\]'( of type 'list')? could not be converted to Integer
                     full_key: test\.param
                     object_type=TestConfig
-
-                Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\."""
+                """
             ).strip(),
             id="run:list_value",
         ),
@@ -1459,8 +1457,6 @@ def test_app_with_error_exception_sanitized(tmpdir: Any, monkeypatch: Any) -> No
         omegaconf\.errors\.ConfigAttributeError: Key 'foo' is not in struct
             full_key: foo
             object_type=dict{suggestion_suffix}
-
-        Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.
         """)
         .strip()
         .format(traceback_line=traceback_line, suggestion_suffix=suggestion_suffix)
@@ -1562,8 +1558,6 @@ class TestTaskRunnerLogging:
                 1 / 0(
                 ~~\^~~)?
             ZeroDivisionError: division by zero
-
-            Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.
             """).strip()
     ],
 )
@@ -1592,7 +1586,6 @@ def test_job_exception_full_error(tmpdir: Any) -> None:
     )
 
     assert "ZeroDivisionError: division by zero" in ret
-    assert "Set the environment variable HYDRA_FULL_ERROR=1" not in ret
 
 
 def test_structured_with_none_list(monkeypatch: Any, tmpdir: Path) -> None:
@@ -1691,8 +1684,6 @@ def test_frozen_primary_config(
                   File "\S*\.py", line \d+, in deprecation_warning
                     raise HydraDeprecationError\(.*\)
                 hydra\.errors\.HydraDeprecationError: Feature FooBar is deprecated
-
-                Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.$
                 """).strip(),
             id="deprecation_error",
         ),
@@ -1859,8 +1850,6 @@ def test_hydra_resolver_in_output_dir(tmpdir: Path, multirun: bool) -> None:
                 1. To use it as a list, use key=[value1,value2]
                 2. To use it as string, quote the value: key=\\'value1,value2\\'
                 3. To sweep over it, add --multirun to your command line
-
-                Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
                 """),
             True,
             False,

--- a/tests/test_hydra_cli_errors.py
+++ b/tests/test_hydra_cli_errors.py
@@ -75,8 +75,6 @@ Trying to use override symbols when extending a list""",
                 """Error parsing override '+key=choice(choice(a,b))'
 ValueError while evaluating 'choice(choice(a,b))': nesting choices is not supported
 See https://hydra.cc/docs/1.2/advanced/override_grammar/basic for details
-
-Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
 """,
             ],
             id="empty choice",
@@ -85,8 +83,6 @@ Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
             "--config-dir=/dir/not/found",
             [
                 f"""Additional config directory '{Path("/dir/not/found").absolute()}' not found
-
-Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
 """
             ],
             id="config_dir_not_found",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -227,8 +227,6 @@ class TestRunAndReport:
                         assert False, "nested_err"
                     AssertionError: nested_err
                     assert False
-
-                    Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.
                     """).strip(),
                 id="strip_run_job_from_top_of_stack",
             ),
@@ -239,8 +237,6 @@ class TestRunAndReport:
                       File "[^"]+", line \d+, in job_calling_omconf
                         OmegaConf.resolve\(123\)  # type: ignore(\n    [~\^]+)?
                     ValueError: Invalid config type \(int\), expected an OmegaConf Container
-
-                    Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.
                     """).strip(),
                 id="strip_omegaconf_from_bottom_of_stack",
             ),
@@ -329,7 +325,6 @@ class TestRunAndReport:
                 assert False, "nested_err"$
             AssertionError: nested_err$
             assert False$
-            Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.$
             """)
         mock_stderr = io.StringIO()
         with (

--- a/website/docs/development/overview.md
+++ b/website/docs/development/overview.md
@@ -14,3 +14,25 @@ Contributor setup instructions are maintained in
 The core Hydra framework supports Python 3.10 through 3.14. You may need to
 create additional environments for different Python versions if CI detects
 issues on a supported Python version.
+
+## Unsanitized tracebacks
+
+When an application raises, Hydra sanitizes the traceback: it strips its own
+frames from the top and OmegaConf frames from the bottom, so that what remains
+points at the application code. That is the right output for someone debugging
+their own app, but it hides the framework internals needed to diagnose a bug in
+Hydra itself.
+
+Set `HYDRA_FULL_ERROR=1` to disable the sanitization and get the complete Hydra
+and OmegaConf call stack:
+
+```bash
+HYDRA_FULL_ERROR=1 python my_app.py
+```
+
+Hydra also skips sanitization automatically when it detects that the process is
+running under a debugger.
+
+This is a framework debugging facility rather than a troubleshooting step for
+application users, so Hydra does not suggest it after runtime failures. Ask for
+it when triaging a bug report that needs the unsanitized traceback.

--- a/website/docs/tutorials/structured_config/1_minimal_example.md
+++ b/website/docs/tutorials/structured_config/1_minimal_example.md
@@ -58,8 +58,6 @@ Traceback (most recent call last):
 omegaconf.errors.ConfigAttributeError: Key 'pork' not in 'MySQLConfig'
         full_key: pork
         object_type=MySQLConfig
-
-Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
 ```
 
 Hydra will also catch typos, or type errors in the command line:


### PR DESCRIPTION
## Motivation

Fixes #3329.

The footer

```text
Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```

followed almost every sanitized error. Since `HYDRA_FULL_ERROR=1` disables the traceback
sanitization and exposes the full Hydra and OmegaConf call stack, presenting it after
routine configuration, override, and task errors advertised a framework debugging facility
as a normal troubleshooting step.

Scoped to #3329 — the recommendations are removed without otherwise changing the
information Hydra presents:

- **Removed the unconditional footer** from `run_and_report()`.
- **Removed the one other user-facing mention**, in `_resolve_target()`:

  ```text
  # before
  Error locating target 'not_found', set env var HYDRA_FULL_ERROR=1 to see chained exception.

  # after
  Error locating target 'not_found'
  ```

  The `raise ... from e` chaining is untouched, so `__cause__` still carries the underlying
  import error. Surfacing that cause in the message itself is a change to the presented
  error information and belongs to #3361, not here.
- **Preserved the mechanism.** `_is_env_set("HYDRA_FULL_ERROR")` and the
  debugger-detection branch are untouched, and the test that runs an app with
  `HYDRA_FULL_ERROR=1` still asserts the unsanitized traceback.
- **Documented it** under `website/docs/development/overview.md` as a framework debugging
  facility, including the note that Hydra also skips sanitization under a debugger, and
  that maintainers can ask for it when triaging a bug report.
- **Updated the affected tests and the current documentation example.**

Verified end to end:

```
$ python tests/test_apps/app_exception/my_app.py
Error executing job with overrides: []
Traceback (most recent call last):
  File ".../my_app.py", line 9, in my_app
    1 / 0
    ~~^~~
ZeroDivisionError: division by zero

$ HYDRA_FULL_ERROR=1 python tests/test_apps/app_exception/my_app.py
# full unsanitized traceback, unchanged
```

### A scope question

I limited the documentation edits to `website/docs/`. The string also appears in
`website/versioned_docs/version-{1.0,1.1,1.2,1.3}/`, four blog posts, and `NEWS.md`, but
those are frozen records of releases where Hydra did print the footer, so changing them
would misreport history. Happy to update them if you would rather the snippets match
current behavior.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes.

### For non-trivial features, API changes, or behavior changes: is there an issue or design discussion where maintainers agreed on the direction?

Yes — #3329, which specifies the goal and the scope, and your review comment above
narrowing `_resolve_target()` to only dropping the reference.

## Test Plan

No special setup beyond a normal core checkout.

Eight test files asserted the footer as part of expected stderr; those expectations are
updated. `test_cannot_locate_target` asserts the shortened message and still verifies the
chained `ImportError`. The `HYDRA_FULL_ERROR=1` test keeps its assertion that the
unsanitized traceback appears; its companion assertion that the footer is absent was
dropped, since the sanitized-path tests now compare exact expected output and cover that
more strongly.

Rebased onto `90a64e2319`.

```
pytest --ignore=tests/test_completion.py   # 2246 passed, 4 failed
```

The 4 failures are pre-existing on `main` and unrelated to this PR — the failing ids are
identical on pristine `90a64e2319`:

```
test_dict_override_materializes_structured_config_with_allow_objects[instantiate2]
test_dict_override_materialized_structured_config_resolves_outside_subtree[instantiate2-none]
test_recursive_instantiation[instantiate2-dict-recursive:direct:dataclass:passthrough]
test_recursive_instantiation[instantiate2-dict_config-recursive:direct:dataclass:passthrough]
```

`ruff format --check .` and `ruff check .` are clean.

Two further environment notes, both reproduced identically on pristine `main` here:

- `tests/test_completion.py` has 130 failures on macOS (zsh/bash shell integration); the
  failing ids are identical to `main`.
- On Python 3.14, seven tests in `tests/test_hydra.py` fail because tracebacks are
  colorized while the assertions are plain substring checks. `PYTHON_COLORS=0` makes those
  pass, which is how the numbers above were produced. Possibly worth its own issue.

## Related Issues and PRs

- Fixes #3329
- Richer exception output in `_resolve_target()` deliberately left to #3361.
