### PR TITLE
Reject OmegaConf syntax in instantiate call-site overrides

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -10,7 +10,7 @@ from enum import Enum
 from textwrap import dedent
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, cast
 
-from omegaconf import AnyNode, DictConfig, OmegaConf, SCMode
+from omegaconf import AnyNode, DictConfig, Node, OmegaConf, SCMode
 from omegaconf._utils import is_structured_config
 from omegaconf.errors import InterpolationResolutionError
 
@@ -401,6 +401,34 @@ def _prepare_input_value(
     return value
 
 
+def _validate_callsite_override(value: Any, path: Tuple[Any, ...]) -> None:
+    if is_structured_config(value):
+        return
+
+    raw_value = value._value() if isinstance(value, Node) else value
+    full_key = ".".join(
+        str(component.value if isinstance(component, Enum) else component)
+        for component in path
+    )
+    if isinstance(raw_value, str) and raw_value == "???":
+        raise InstantiationException(
+            f"Call-site override '{full_key}' cannot be an OmegaConf missing value. "
+            "Pass a concrete runtime value instead."
+        )
+    if isinstance(raw_value, str) and "${" in raw_value:
+        raise InstantiationException(
+            f"Call-site override '{full_key}' cannot be an OmegaConf interpolation. "
+            "Pass a concrete runtime value instead."
+        )
+
+    if isinstance(value, dict):
+        for key, child in value.items():
+            _validate_callsite_override(child, (*path, key))
+    elif isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            _validate_callsite_override(child, (*path, index))
+
+
 def _resolve_target(
     target: Union[str, type, Callable[..., Any]],
     full_key: str,
@@ -490,6 +518,9 @@ def instantiate(
     :param kwargs: Optional named parameters to override
                    parameters in the config object. Parameters not present
                    in the config objects are being passed as is to the target.
+                   Plain Python missing values and interpolation syntax are not
+                   supported in call-site overrides; pass concrete runtime
+                   values or an explicit OmegaConf container instead.
                    A dict replaces a configured plain mapping, but merges into
                    a configured Structured Config or target config.
                    Dataclass and attrs instances are passed through without
@@ -503,6 +534,11 @@ def instantiate(
         return None
 
     target_whitelist = _resolve_target_whitelist(_target_whitelist_)
+
+    for index, value in enumerate(args):
+        _validate_callsite_override(value, (_Keys.ARGS, index))
+    for key, value in kwargs.items():
+        _validate_callsite_override(value, (key,))
 
     if isinstance(config, (dict, list)) or type(config) is tuple:
         config = _prepare_input_container(config)

--- a/news/3216.api_change
+++ b/news/3216.api_change
@@ -5,3 +5,6 @@ configured OmegaConf containers passed as target arguments retain their
 identity, so mutations to them affect the input configuration. See the
 [Hydra 1.4 instantiate migration guide](https://hydra.cc/docs/upgrades/1.3_to_1.4/instantiate_resolution/)
 for details.
+Plain Python call-site overrides must be concrete runtime values; `???` and
+interpolation syntax are rejected. Explicit OmegaConf containers retain normal
+OmegaConf semantics.

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -207,12 +207,6 @@ def register_test_resolver(name: str, value: Any) -> Any:
             id="class+override+partial1",
         ),
         param(
-            {"_target_": "tests.instantiate.AClass", "b": 20, "c": 30},
-            {"a": "???", "_partial_": True},
-            partial(AClass, b=20, c=30),
-            id="class+override+partial1+missing",
-        ),
-        param(
             {
                 "_target_": "tests.instantiate.AClass",
                 "_partial_": True,
@@ -486,22 +480,6 @@ def test_callsite_override_is_visible_through_absolute_interpolation(
     assert config.node.base == 10
 
 
-@mark.parametrize("base", ["${literal}", "before ${literal} after"])
-def test_callsite_override_remains_literal_when_referenced_by_config(
-    instantiate_func: Any, base: str
-) -> None:
-    result = instantiate_func(
-        {
-            "_target_": "tests.instantiate.ArgsClass",
-            "base": "configured",
-            "derived": "${base}",
-        },
-        base=base,
-    )
-
-    assert result.kwargs == {"base": base, "derived": base}
-
-
 def test_callsite_runtime_object_is_visible_to_configured_interpolation(
     instantiate_func: Any,
 ) -> None:
@@ -622,6 +600,69 @@ def test_instantiate_with_missing(instantiate_func: Any) -> Any:
     }
     with raises(MissingMandatoryValue, match=re.escape("Missing mandatory value: a")):
         instantiate_func(config)
+
+
+@mark.parametrize(
+    "value",
+    [
+        param("???", id="missing"),
+        param("${configured}", id="interpolation"),
+        param({"nested": "???"}, id="nested_missing"),
+        param({"nested": "${configured}"}, id="nested_interpolation"),
+        param(["???"], id="list_missing"),
+        param(("${configured}",), id="tuple_interpolation"),
+    ],
+)
+def test_callsite_override_rejects_omegaconf_syntax(
+    instantiate_func: Any, value: Any
+) -> None:
+    config = {
+        "_target_": "tests.instantiate.ArgsClass",
+        "configured": 10,
+    }
+
+    with raises(InstantiationException, match="Call-site override"):
+        instantiate_func(config, value=value)
+
+
+@mark.parametrize(
+    "value", [param("???", id="missing"), param("${value}", id="interpolation")]
+)
+def test_callsite_positional_override_rejects_omegaconf_syntax(
+    instantiate_func: Any, value: str
+) -> None:
+    config = {"_target_": "tests.instantiate.ArgsClass"}
+
+    with raises(
+        InstantiationException,
+        match=re.escape("Call-site override '_args_.0'"),
+    ):
+        instantiate_func(config, value)
+
+
+def test_callsite_override_does_not_inspect_structured_runtime_value(
+    instantiate_func: Any,
+) -> None:
+    @dataclass
+    class DictRuntimeValue(dict):  # type: ignore[type-arg]
+        pass
+
+    @attr.define(slots=False)
+    class ListRuntimeValue(list):  # type: ignore[type-arg]
+        pass
+
+    mapping = DictRuntimeValue()
+    mapping["value"] = "${literal}"
+    sequence = ListRuntimeValue()
+    sequence.append("???")
+
+    for value in (mapping, sequence):
+        result = instantiate_func(
+            {"_target_": "tests.instantiate.ArgsClass"},
+            value=value,
+        )
+
+        assert result.kwargs["value"] is value
 
 
 def test_none_cases(

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -163,6 +163,11 @@ arguments resolve against those call-site values. Call-site values are not
 generally coerced against Structured Config fields. Dictionary overrides of
 Structured Config nodes are the exception, as described below.
 
+Plain Python call-site overrides must be concrete runtime values. Hydra rejects
+`???` and strings containing OmegaConf interpolation syntax (`${...}`),
+including inside native containers. Explicit OmegaConf containers retain
+normal OmegaConf semantics and may contain missing values or interpolations.
+
 Configuration values are resolved lazily as instantiation proceeds instead of
 resolving the full configuration tree up front. Calls on OmegaConf inputs
 without call-site overrides do not make an additional input copy. When

--- a/website/docs/upgrades/1.3_to_1.4/breaking_changes.md
+++ b/website/docs/upgrades/1.3_to_1.4/breaking_changes.md
@@ -66,6 +66,9 @@ have been removed:
 - `hydra.utils.instantiate()` passes dataclass and attrs instances supplied as
   call-site arguments through unchanged instead of interpreting them as
   Structured Configs.
+- `hydra.utils.instantiate()` rejects `???` and interpolation syntax in plain
+  Python call-site overrides. Supply concrete runtime values or explicit
+  OmegaConf containers instead.
 - `hydra.utils.instantiate()` resolves interpolations during recursive
   traversal instead of resolving the entire configuration before
   instantiation. With `_recursive_=False`, `_convert_="none"`, and no call-site

--- a/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
+++ b/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
@@ -47,6 +47,11 @@ values, native `list`, `tuple`, and `dict` containers, and OmegaConf containers
 remain supported configuration inputs. They retain Hydra's normal
 instantiation and conversion where applicable.
 
+Plain Python call-site overrides must be concrete runtime values. Hydra rejects
+`???` and strings containing OmegaConf interpolation syntax (`${...}`),
+including inside native containers. Explicit OmegaConf containers retain
+normal OmegaConf semantics and may contain missing values or interpolations.
+
 When a `dict` or `DictConfig` call-site argument overrides a parameter of the
 target being instantiated, it is handled according to the configured parameter
 value:


### PR DESCRIPTION
Plain Python call-site arguments to instantiate() are runtime values, not configuration fragments. Reject missing-value and interpolation syntax recursively in dictionary, list, and tuple values so these strings cannot acquire OmegaConf semantics accidentally.

Explicit OmegaConf containers retain normal OmegaConf behavior. Structured Config instances and non-container runtime objects remain pass-through values and are not recursively inspected.

This is stacked on https://github.com/facebookresearch/hydra/pull/3356.

Checks:
- Focused instantiate tests
- Ruff check and format check
- Pyrefly