### PR TITLE
Avoid passing default object_store_memory when connecting to existing Ray cluster (Issue #2893)

### DIFF
--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core.py
@@ -32,12 +32,10 @@ def launch(
         f"sweep output dir: {sweep_dir}"
     )
 
-    # Avoid allocating too little memory in CI https://github.com/ray-project/ray/issues/11966#issuecomment-1318100747
     ray_init = cast(
         DictConfig,
         OmegaConf.create(OmegaConf.to_container(launcher.ray_cfg.init, resolve=True)),
     )
-    ray_init.setdefault("object_store_memory", 78643200)
     start_ray(ray_init)
 
     runs = []

--- a/plugins/hydra_ray_launcher/news/2893.bugfix
+++ b/plugins/hydra_ray_launcher/news/2893.bugfix
@@ -1,0 +1,1 @@
+Avoid default object_store_memory when connecting to an existing Ray cluster

--- a/plugins/hydra_ray_launcher/tests/test_ray_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_launcher.py
@@ -32,7 +32,10 @@ def test_discovery() -> None:
 
 
 @mark.skipif(sys.platform.startswith("win"), reason=win_msg)
-@mark.parametrize("launcher_name, overrides", [("ray", [])])
+@mark.parametrize(
+    "launcher_name, overrides",
+    [("ray", ["+hydra.launcher.ray.init.object_store_memory=78643200"])],
+)
 class TestRayLauncher(LauncherTestSuite):
     """
     Run the Launcher test suite on this launcher.
@@ -52,6 +55,7 @@ class TestRayLauncher(LauncherTestSuite):
                 "hydra/launcher=ray",
                 "hydra/hydra_logging=hydra_debug",
                 "hydra/job_logging=disabled",
+                "+hydra.launcher.ray.init.object_store_memory=78643200",
             ],
         )
     ],
@@ -118,3 +122,68 @@ def test_ray_aws_launch_does_not_mutate_launcher_config(
         "pip install example==1.0",
         "cluster",
     ]
+
+
+def test_ray_launcher_object_store_memory(monkeypatch: Any, tmp_path: Path) -> None:
+    from hydra_plugins.hydra_ray_launcher import _core
+
+    cfg = OmegaConf.create(
+        {
+            "hydra": {
+                "hydra_logging": {},
+                "verbose": False,
+                "sweep": {"dir": str(tmp_path)},
+            },
+        }
+    )
+
+    # Test cases: (configured_address, configured_memory, expected_memory)
+    test_cases = [
+        # Ordinary local launch (no address, no memory configured) -> no injected value
+        (None, None, None),
+        # Existing cluster connection -> no injected value
+        ("auto", None, None),
+        # Explicit memory configured -> remains untouched
+        (None, 12345, 12345),
+        # Explicit memory configured on existing cluster -> remains untouched
+        ("auto", 12345, 12345),
+    ]
+
+    for address, memory, expected_memory in test_cases:
+        init_cfg: dict[str, Any] = {}
+        if address is not None:
+            init_cfg["address"] = address
+        if memory is not None:
+            init_cfg["object_store_memory"] = memory
+
+        ray_cfg = OmegaConf.create(
+            {
+                "init": init_cfg,
+                "remote": {},
+            }
+        )
+
+        launcher = SimpleNamespace(
+            config=cfg,
+            hydra_context=object(),
+            ray_cfg=ray_cfg,
+            task_function=lambda: None,
+        )
+
+        captured_ray_init = None
+
+        def mock_start_ray(ray_init: Any) -> None:
+            nonlocal captured_ray_init
+            captured_ray_init = ray_init
+
+        monkeypatch.setattr(_core, "start_ray", mock_start_ray)
+        monkeypatch.setattr(_core, "configure_log", lambda *args: None)
+
+        res = _core.launch(cast(RayLauncher, launcher), [], 0)
+        assert res == []
+
+        assert captured_ray_init is not None
+        if expected_memory is not None:
+            assert captured_ray_init.get("object_store_memory") == expected_memory
+        else:
+            assert "object_store_memory" not in captured_ray_init


### PR DESCRIPTION
Fixes #2893

### Summary
The Hydra Ray launcher was injecting `object_store_memory=78643200` into every `ray.init()` call as an old CI workaround. Ray rejects resource configuration settings when connecting to an existing cluster, so this PR removes the automatic production default entirely. Users can still configure `hydra.launcher.ray.init.object_store_memory` explicitly when needed.

### Changes
1. **Core fix**: Removed automatic `object_store_memory` injection from `plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core.py`.
2. **Focused coverage**: Added a unit test covering local and existing-cluster addresses, both with and without an explicitly configured `object_store_memory`, while verifying that the launch path reaches `start_ray()`.
3. **Integration tests**: Configured the historical memory value explicitly where the test environment requires it.
4. **Cleanup**: Removed unnecessary Windows Ray mocks.
5. **News fragment**: Added `plugins/hydra_ray_launcher/news/2893.bugfix`.