### PR TITLE
Reject backslashes in Defaults List paths

### DIFF
--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -411,7 +411,7 @@ def _resolve_deferred_interpolations(
                 # Another deferred subtree may provide the missing choice.
                 continue
 
-            _check_parent_traversal(candidate, tree.node)
+            _validate_paths(candidate, tree.node)
             candidate.update_parent(
                 tree.node.get_group_path(),
                 tree.node.get_final_package(),
@@ -452,7 +452,7 @@ def _resolve_deferred_interpolations(
     fail_on_unresolved(root)
 
 
-def _check_parent_traversal(default: InputDefault, parent: InputDefault) -> None:
+def _validate_paths(default: InputDefault, parent: InputDefault) -> None:
     if isinstance(default, ConfigDefault):
         assert default.path is not None
         paths = [("config", default.path)]
@@ -469,6 +469,22 @@ def _check_parent_traversal(default: InputDefault, parent: InputDefault) -> None
         return
 
     for path_type, path in paths:
+        # Check for backslashes before parent traversal: the traversal check
+        # splits on '/', so a path like '..\secret' would otherwise slip through
+        # as a single segment and reach operating-system path handling, where
+        # Windows interprets '\' as a separator but POSIX and ConfigStore do not.
+        if "\\" in path:
+            location = ""
+            if not parent.is_virtual():
+                location = f"In {parent.get_config_path()}: "
+            raise ConfigCompositionException(
+                f"{location}Backslash ('\\') in Defaults List "
+                f"{path_type} paths is not supported ('{path}').\n"
+                "Use '/' as the config group separator; it is the only "
+                "supported separator, regardless of the operating system.\n"
+                "See https://hydra.cc/docs/advanced/defaults_list/ for more "
+                "information."
+            )
         if ".." not in path.split("/"):
             continue
 
@@ -612,7 +628,7 @@ def _create_defaults_tree_impl(
         defaults_list.extend(overrides.append_group_defaults)
 
     for d in defaults_list:
-        _check_parent_traversal(d, parent)
+        _validate_paths(d, parent)
 
     _update_overrides(defaults_list, overrides, parent, interpolated_subtree)
 
@@ -651,7 +667,7 @@ def _create_defaults_tree_impl(
                 assert isinstance(d, GroupDefault)
                 overrides.override_default_option(d)
 
-            _check_parent_traversal(d, parent)
+            _validate_paths(d, parent)
 
             if isinstance(d, GroupDefault) and d.is_options():
                 # overriding may change from options to name

--- a/news/3362.api_change
+++ b/news/3362.api_change
@@ -1,0 +1,1 @@
+Reject backslashes in Defaults List config group and option paths; '/' is the only supported config group separator.

--- a/tests/defaults_list/data/error_backslash_config.yaml
+++ b/tests/defaults_list/data/error_backslash_config.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - group1\file1

--- a/tests/defaults_list/data/error_backslash_config_traversal.yaml
+++ b/tests/defaults_list/data/error_backslash_config_traversal.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - ..\secret

--- a/tests/defaults_list/data/error_backslash_group.yaml
+++ b/tests/defaults_list/data/error_backslash_group.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - group1\group2: file1

--- a/tests/defaults_list/data/error_backslash_interpolation.yaml
+++ b/tests/defaults_list/data/error_backslash_interpolation.yaml
@@ -1,0 +1,3 @@
+defaults:
+  - group1: file1
+  - group2: ${group1}\extra

--- a/tests/defaults_list/data/error_backslash_option.yaml
+++ b/tests/defaults_list/data/error_backslash_option.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - group1: ..\file1

--- a/tests/defaults_list/data/error_backslash_options.yaml
+++ b/tests/defaults_list/data/error_backslash_options.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - group1:
+      - file1
+      - sub\file1

--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -6,7 +6,7 @@ from typing import Any, List, Optional
 from pytest import mark, param, raises
 
 from hydra._internal.defaults_list import (
-    _check_parent_traversal,
+    _validate_paths,
     _validate_self,
     create_defaults_list,
 )
@@ -2248,7 +2248,92 @@ def test_parent_traversal_substring_is_allowed(default: InputDefault) -> None:
     parent = ConfigDefault(path="empty")
     parent.update_parent("", "")
 
-    _check_parent_traversal(default, parent)
+    _validate_paths(default, parent)
+
+
+@mark.parametrize(
+    "config_name,overrides,error_path_type,error_path",
+    [
+        param(
+            "error_backslash_config",
+            [],
+            "config",
+            "group1\\file1",
+            id="config",
+        ),
+        param(
+            "error_backslash_group",
+            [],
+            "config group",
+            "group1\\group2",
+            id="config-group",
+        ),
+        param(
+            "error_backslash_option",
+            [],
+            "config option",
+            "..\\file1",
+            id="config-option-traversal-bypass",
+        ),
+        param(
+            "error_backslash_options",
+            [],
+            "config option",
+            "sub\\file1",
+            id="config-options-list",
+        ),
+        param(
+            "error_backslash_interpolation",
+            [],
+            "config option",
+            "${group1}\\extra",
+            id="config-option-interpolation",
+        ),
+        param(
+            "empty",
+            ["+group1=..\\file1"],
+            "config option",
+            "..\\file1",
+            id="cli-append-option",
+        ),
+        param(
+            "empty",
+            ["+group1=[file1,sub\\file1]"],
+            "config option",
+            "sub\\file1",
+            id="cli-append-options-list",
+        ),
+        param(
+            "group_default",
+            ["group1=sub\\file1"],
+            "config option",
+            "sub\\file1",
+            id="cli-override-option",
+        ),
+    ],
+)
+def test_backslash_error(
+    config_name: str,
+    overrides: List[str],
+    error_path_type: str,
+    error_path: str,
+) -> None:
+    expected = raises(
+        ConfigCompositionException,
+        match=re.escape(
+            "Backslash ('\\') in Defaults List "
+            f"{error_path_type} paths is not supported ('{error_path}').\n"
+            "Use '/' as the config group separator; it is the only "
+            "supported separator, regardless of the operating system.\n"
+            "See https://hydra.cc/docs/advanced/defaults_list/ for more "
+            "information."
+        ),
+    )
+    _test_defaults_list_impl(
+        config_name=config_name,
+        overrides=overrides,
+        expected=expected,
+    )
 
 
 def test_parent_traversal_error_explains_supported_paths() -> None:

--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -2269,6 +2269,13 @@ def test_parent_traversal_substring_is_allowed(default: InputDefault) -> None:
             id="config-group",
         ),
         param(
+            "error_backslash_config_traversal",
+            [],
+            "config",
+            "..\\secret",
+            id="config-traversal-bypass",
+        ),
+        param(
             "error_backslash_option",
             [],
             "config option",
@@ -2332,6 +2339,25 @@ def test_backslash_error(
     _test_defaults_list_impl(
         config_name=config_name,
         overrides=overrides,
+        expected=expected,
+    )
+
+
+def test_backslash_error_includes_location_prefix() -> None:
+    expected = raises(
+        ConfigCompositionException,
+        match=re.escape(
+            "In error_backslash_option: Backslash ('\\') in Defaults List "
+            "config option paths is not supported ('..\\file1').\n"
+            "Use '/' as the config group separator; it is the only "
+            "supported separator, regardless of the operating system.\n"
+            "See https://hydra.cc/docs/advanced/defaults_list/ for more "
+            "information."
+        ),
+    )
+    _test_defaults_list_impl(
+        config_name="error_backslash_option",
+        overrides=[],
         expected=expected,
     )
 

--- a/website/docs/advanced/defaults_list.md
+++ b/website/docs/advanced/defaults_list.md
@@ -43,7 +43,9 @@ traversal. Select the target config directly instead. Use an absolute config
 path or group such as `/config` or `/group: option` in a Defaults List. In a
 command-line override, target the group directly with `group=option`, using
 `+group=option` when adding a new default.
-The path separator is `/` regardless of the operating system.
+The path separator is `/` regardless of the operating system. A backslash
+(`\`) is not a path separator and is rejected anywhere in a Defaults List
+config path.
 
 *OPTION*: The currently selected *CONFIG_NAME* or *CONFIG_NAMES* from a *CONFIG_GROUP*.
 

--- a/website/docs/upgrades/1.3_to_1.4/breaking_changes.md
+++ b/website/docs/upgrades/1.3_to_1.4/breaking_changes.md
@@ -18,6 +18,10 @@ complete. The final release notes will be the authoritative list.
   included in a stable Hydra release, but was available in Hydra 1.4
   development versions from February 2025 through July 2026.
 - Parent traversal in Defaults List config paths is no longer accepted.
+- Backslashes in Defaults List config paths are no longer accepted. `/` is the
+  only supported config group separator. Paths that used `\` previously
+  composed on Windows only, where the operating system resolved the backslash
+  as a filesystem separator.
 
 ### Hydra 1.1 compatibility behavior
 


### PR DESCRIPTION
Closes #3362

Backslashes in Defaults List paths were never rejected, so behavior depended on the platform: `FileConfigSource` hands paths to OS path handling, where Windows treats `\` as a separator while POSIX and `ConfigStore` treat it as a literal character. A path like `..\secret` also slipped past the parent traversal check, which splits on `/` only, so the `..` never showed up as its own segment.

This rejects `\` anywhere in a Defaults List config, config group, or config option path with a `ConfigCompositionException` pointing users at `/`. No normalization, per the issue: `/` stays the only supported separator.

Implementation: the check lives in `_check_parent_traversal`, which I renamed to `_validate_paths` since it now validates two things. That function is already called in the three right places, including on resolved deferred interpolations, so interpolated values are covered without new plumbing. The backslash check runs before the traversal check so `..\secret` reports the actual problem.

Tests cover config paths, group paths, single options, options lists, an interpolated value with a literal backslash, and the three command line forms (override, append, append list), which I verified all flow into the same validation. Also verified the pre-change behavior on this branch's parent: the first three error configs composed without any error at the defaults-list level, which is exactly the silent pass-through the issue describes.

Ran `tests/defaults_list` (136 passed), `tests/test_config_loader.py` + `tests/test_compose.py` (223 passed), ruff check/format, yamllint on the new data files, and pyrefly on `defaults_list.py`, all clean. News fragment and the defaults list doc's separator note included.


---

Update: @adarshsm independently built the same fix in #3366 and closed it in favor of this PR. I folded in the three gaps they flagged (4ccac8f): a `..\secret` case for bare config paths, which exercises the `ConfigDefault` branch; a full-message test asserting the `In <config>:` location prefix; and a bullet on the 1.3 to 1.4 breaking changes page next to the parent traversal one. Their PR also documents why a resolution-produced backslash test is not constructible: Defaults List interpolation only substitutes known group choices, which are themselves validated first. The check stays wired at the deferred-resolution call site as defense in depth.
