### PR TITLE
Reject backslashes in Defaults List paths

### DIFF
--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -411,7 +411,7 @@ def _resolve_deferred_interpolations(
                 # Another deferred subtree may provide the missing choice.
                 continue
 
-            _check_parent_traversal(candidate, tree.node)
+            _check_defaults_list_paths(candidate, tree.node)
             candidate.update_parent(
                 tree.node.get_group_path(),
                 tree.node.get_final_package(),
@@ -452,7 +452,7 @@ def _resolve_deferred_interpolations(
     fail_on_unresolved(root)
 
 
-def _check_parent_traversal(default: InputDefault, parent: InputDefault) -> None:
+def _check_defaults_list_paths(default: InputDefault, parent: InputDefault) -> None:
     if isinstance(default, ConfigDefault):
         assert default.path is not None
         paths = [("config", default.path)]
@@ -467,6 +467,22 @@ def _check_parent_traversal(default: InputDefault, parent: InputDefault) -> None
             paths.extend(("config option", option) for option in default.get_options())
     else:
         return
+
+    def _location() -> str:
+        if parent.is_virtual():
+            return ""
+        return f"In {parent.get_config_path()}: "
+
+    for path_type, path in paths:
+        if "\\" in path:
+            raise ConfigCompositionException(
+                f"{_location()}Backslashes in Defaults List "
+                f"{path_type} paths are not supported ('{path}').\n"
+                "Hydra uses '/' as the config group separator on every platform. "
+                "Use '/' instead.\n"
+                "See https://hydra.cc/docs/advanced/defaults_list/ for more "
+                "information."
+            )
 
     for path_type, path in paths:
         if ".." not in path.split("/"):
@@ -484,11 +500,8 @@ def _check_parent_traversal(default: InputDefault, parent: InputDefault) -> None
                 "command line."
             ),
         }[path_type]
-        location = ""
-        if not parent.is_virtual():
-            location = f"In {parent.get_config_path()}: "
         raise ConfigCompositionException(
-            f"{location}Parent traversal ('..') in Defaults List "
+            f"{_location()}Parent traversal ('..') in Defaults List "
             f"{path_type} paths is not supported ('{path}').\n"
             f"{guidance}\n"
             "See https://hydra.cc/docs/advanced/defaults_list/ for more "
@@ -612,7 +625,7 @@ def _create_defaults_tree_impl(
         defaults_list.extend(overrides.append_group_defaults)
 
     for d in defaults_list:
-        _check_parent_traversal(d, parent)
+        _check_defaults_list_paths(d, parent)
 
     _update_overrides(defaults_list, overrides, parent, interpolated_subtree)
 
@@ -651,7 +664,7 @@ def _create_defaults_tree_impl(
                 assert isinstance(d, GroupDefault)
                 overrides.override_default_option(d)
 
-            _check_parent_traversal(d, parent)
+            _check_defaults_list_paths(d, parent)
 
             if isinstance(d, GroupDefault) and d.is_options():
                 # overriding may change from options to name

--- a/news/3362.api_change
+++ b/news/3362.api_change
@@ -1,0 +1,1 @@
+Reject backslashes in Defaults List config, config group and config option paths.

--- a/tests/defaults_list/data/error_backslash_config.yaml
+++ b/tests/defaults_list/data/error_backslash_config.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - group1\file1

--- a/tests/defaults_list/data/error_backslash_group.yaml
+++ b/tests/defaults_list/data/error_backslash_group.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - group1\subgroup: file1

--- a/tests/defaults_list/data/error_backslash_interpolation.yaml
+++ b/tests/defaults_list/data/error_backslash_interpolation.yaml
@@ -1,0 +1,3 @@
+defaults:
+  - group1: file1
+  - group2: sub\${group1}

--- a/tests/defaults_list/data/error_backslash_option.yaml
+++ b/tests/defaults_list/data/error_backslash_option.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - group1: sub\file1

--- a/tests/defaults_list/data/error_backslash_options.yaml
+++ b/tests/defaults_list/data/error_backslash_options.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - group1:
+      - file1
+      - sub\file1

--- a/tests/defaults_list/data/error_backslash_traversal_config.yaml
+++ b/tests/defaults_list/data/error_backslash_traversal_config.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - ..\group1/file1

--- a/tests/defaults_list/data/error_backslash_traversal_option.yaml
+++ b/tests/defaults_list/data/error_backslash_traversal_option.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - group1: ..\file1

--- a/tests/defaults_list/data/group1/error_backslash_config.yaml
+++ b/tests/defaults_list/data/group1/error_backslash_config.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - ..\group2/file1

--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -6,7 +6,7 @@ from typing import Any, List, Optional
 from pytest import mark, param, raises
 
 from hydra._internal.defaults_list import (
-    _check_parent_traversal,
+    _check_defaults_list_paths,
     _validate_self,
     create_defaults_list,
 )
@@ -2248,7 +2248,7 @@ def test_parent_traversal_substring_is_allowed(default: InputDefault) -> None:
     parent = ConfigDefault(path="empty")
     parent.update_parent("", "")
 
-    _check_parent_traversal(default, parent)
+    _check_defaults_list_paths(default, parent)
 
 
 def test_parent_traversal_error_explains_supported_paths() -> None:
@@ -2265,6 +2265,115 @@ def test_parent_traversal_error_explains_supported_paths() -> None:
     )
     _test_defaults_list_impl(
         config_name="group1/error_parent_traversal_config",
+        overrides=[],
+        expected=expected,
+    )
+
+
+@mark.parametrize(
+    "config_name,overrides,error_path_type,error_path",
+    [
+        param(
+            "error_backslash_config",
+            [],
+            "config",
+            "group1\\file1",
+            id="config",
+        ),
+        param(
+            "error_backslash_group",
+            [],
+            "config group",
+            "group1\\subgroup",
+            id="config-group",
+        ),
+        param(
+            "error_backslash_option",
+            [],
+            "config option",
+            "sub\\file1",
+            id="config-option",
+        ),
+        param(
+            "error_backslash_options",
+            [],
+            "config option",
+            "sub\\file1",
+            id="config-options-list",
+        ),
+        param(
+            "error_backslash_traversal_config",
+            [],
+            "config",
+            "..\\group1/file1",
+            id="config-parent-traversal",
+        ),
+        param(
+            "error_backslash_traversal_option",
+            [],
+            "config option",
+            "..\\file1",
+            id="config-option-parent-traversal",
+        ),
+        param(
+            "error_backslash_interpolation",
+            [],
+            "config option",
+            "sub\\${group1}",
+            id="config-option-with-interpolation",
+        ),
+        param(
+            "empty",
+            ["+group1=sub\\file1"],
+            "config option",
+            "sub\\file1",
+            id="cli-append-option",
+        ),
+        param(
+            "group_default",
+            ["group1=..\\file1"],
+            "config option",
+            "..\\file1",
+            id="cli-override-option-parent-traversal",
+        ),
+    ],
+)
+def test_backslash_error(
+    config_name: str,
+    overrides: List[str],
+    error_path_type: str,
+    error_path: str,
+) -> None:
+    expected = raises(
+        ConfigCompositionException,
+        match=re.escape(
+            f"Backslashes in Defaults List {error_path_type} paths are not "
+            f"supported ('{error_path}').\n"
+            "Hydra uses '/' as the config group separator on every platform. "
+            "Use '/' instead."
+        ),
+    )
+    _test_defaults_list_impl(
+        config_name=config_name,
+        overrides=overrides,
+        expected=expected,
+    )
+
+
+def test_backslash_error_explains_supported_separator() -> None:
+    expected = raises(
+        ConfigCompositionException,
+        match=re.escape(
+            "In group1/error_backslash_config: Backslashes in Defaults List "
+            "config paths are not supported ('..\\group2/file1').\n"
+            "Hydra uses '/' as the config group separator on every platform. "
+            "Use '/' instead.\n"
+            "See https://hydra.cc/docs/advanced/defaults_list/ for more "
+            "information."
+        ),
+    )
+    _test_defaults_list_impl(
+        config_name="group1/error_backslash_config",
         overrides=[],
         expected=expected,
     )

--- a/website/docs/advanced/defaults_list.md
+++ b/website/docs/advanced/defaults_list.md
@@ -43,7 +43,10 @@ traversal. Select the target config directly instead. Use an absolute config
 path or group such as `/config` or `/group: option` in a Defaults List. In a
 command-line override, target the group directly with `group=option`, using
 `+group=option` when adding a new default.
-The path separator is `/` regardless of the operating system.
+The path separator is `/` regardless of the operating system. A backslash is not
+a path separator: `\` is rejected in Defaults List config, config group and
+config option paths, so that a Defaults List composes identically on every
+platform.
 
 *OPTION*: The currently selected *CONFIG_NAME* or *CONFIG_NAMES* from a *CONFIG_GROUP*.
 

--- a/website/docs/upgrades/1.3_to_1.4/breaking_changes.md
+++ b/website/docs/upgrades/1.3_to_1.4/breaking_changes.md
@@ -18,6 +18,8 @@ complete. The final release notes will be the authoritative list.
   included in a stable Hydra release, but was available in Hydra 1.4
   development versions from February 2025 through July 2026.
 - Parent traversal in Defaults List config paths is no longer accepted.
+- Backslashes in Defaults List config paths are no longer accepted. Use `/`,
+  which is the config group separator on every platform.
 
 ### Hydra 1.1 compatibility behavior
 


### PR DESCRIPTION
## Motivation

Fixes #3362.

Hydra uses `/` as the config group separator, but `\` was never explicitly rejected. Two things follow from that, both reproduced on `main`:

**1. Composition is platform-dependent.** `FileConfigSource` passes paths through operating system path handling, so Windows can read `\` as a filesystem separator while POSIX and `ConfigStore` treat it as a literal character.

**2. A backslash bypasses the parent traversal check.** That check splits on `/` only, so `"..\secret".split("/")` is `["..\\secret"]` — no `..` segment, no error:

```
- ../secret   ->  ConfigCompositionException: Parent traversal ('..') in Defaults List config paths is not supported ('../secret').
- ..\secret   ->  MissingConfigException: Could not load 'nested/..\secret'
```

The `/` form is rejected; the `\` form reaches the config source, where the OS resolves it on Windows.

This PR rejects `\` in Defaults List config, config group and config option paths with an error pointing at `/`. Backslashes are **not** normalized into `/`, per the issue — `/` stays the only supported separator.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

### For non-trivial features, API changes, or behavior changes: is there an issue or design discussion where maintainers agreed on the direction?

#3362, which specifies the behavior: reject rather than normalize, cover interpolated values, and add platform-independent tests.

## Implementation notes

Two points worth your veto:

**The rename.** I extended `_check_parent_traversal` rather than adding a parallel function, because it already collects exactly the paths that need checking (config path, config group, config option / options list) and is already called from all three relevant sites — raw Defaults List entries, entries after override application, and interpolation candidates resolved in the deferred pass. That last one is what gives the issue's "including values produced by interpolation" for free. Since the function now checks two unrelated things, I renamed it to `_check_defaults_list_paths`; happy to revert the rename and duplicate the path collection instead if you prefer the smaller diff.

The backslash pass runs *before* the traversal pass, so `..\secret` reports the backslash — the actionable error — rather than the traversal.

**Interpolation coverage is weaker than it looks, and I did not paper over it.** I tried to build a test where resolution *introduces* a backslash and could not, because Defaults List interpolation is not general OmegaConf resolution: `_resolve_interpolation_impl` substitutes only known group choices and raises if any `${` survives. So a resolved value can only be something a group was already legally set to, and any such value containing `\` is rejected at the raw check first. The test therefore asserts the honest behavior — `sub\${group1}` is rejected with the unresolved text. The check still applies at the deferred-resolution call site as defense in depth, at no extra cost since it is the same function.

## Test Plan

No special setup. `pytest tests/defaults_list/`.

10 new tests in `tests/defaults_list/test_defaults_list.py`, mirroring the existing `test_parent_traversal_error` structure: config, config group, config option, options list, `..\` traversal for both config and option paths, an interpolated option, two command-line override forms, and a full-message test covering the `In <config>: ` location prefix. All are platform-independent — they assert on the raised `ConfigCompositionException`, not on filesystem behavior.

Verified red before green: reverting only `hydra/_internal/defaults_list.py` gives 10 failures, and the fix turns them green. Full suite passes locally (2233 passed; the 4 `tests/instantiate/test_instantiate.py` failures on my machine are pre-existing and identical on unmodified `main`). `ruff format`, `ruff check`, `yamllint --strict .` clean.

Also documented in `website/docs/advanced/defaults_list.md`, added a bullet to the 1.3→1.4 breaking changes page next to the parent traversal one, and added `news/3362.api_change`.

## Related Issues and PRs

- Closes #3362
- Related to #3202 (parent traversal), whose validation this extends
- Discovered while reviewing #3350
