### PR TITLE
Test config search path string output

### DIFF
--- a/tests/test_config_search_path.py
+++ b/tests/test_config_search_path.py
@@ -22,6 +22,10 @@ def to_tuples_list(
     return [(x.provider, x.path) for x in search_path.config_search_path]
 
 
+def test_str() -> None:
+    assert str(create_search_path([("foo", "/path")])) == "[provider=foo, path=/path]"
+
+
 @mark.parametrize(
     "input_list, reference, expected_idx",
     [


### PR DESCRIPTION
## Summary

- verify the rendered config search path includes its provider and path
- cover `ConfigSearchPathImpl.__str__` as part of #802

## Tests

- `pytest -q tests/test_config_search_path.py`
- `ruff format --check tests/test_config_search_path.py`
- `ruff check tests/test_config_search_path.py`