### PR TITLE
Reduce GitHub Actions queue pressure

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,12 +2,16 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "0.11_branch", "1.0_branch", "1.1_branch", "1.2_branch", "gh-pages" ]
+    branches: [ "main", "0.11_branch", "1.0_branch", "1.1_branch", "1.2_branch" ]
   pull_request:
     branches:
       - main
   schedule:
     - cron: "33 9 * * 0"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -8,10 +8,19 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - .github/workflows/deploy_website.yml
+      - website/**
+      - tools/landscape/data/decisions.json
+      - tools/landscape/build_public_landscape.py
 
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   deploy:
@@ -31,7 +40,12 @@ jobs:
         WEBSITE_GITHUB_TOKEN: ${{ github.event_name != 'pull_request' && secrets.WEBSITE_GITHUB_TOKEN || '' }}
         IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
       run: |
-        PATHS=(website tools/landscape/data/decisions.json tools/landscape/build_public_landscape.py)
+        PATHS=(
+          .github/workflows/deploy_website.yml
+          website
+          tools/landscape/data/decisions.json
+          tools/landscape/build_public_landscape.py
+        )
         git fetch
         REV=$(git log -5 --pretty=oneline origin/gh-pages | grep "Deploy website" |  awk 'NF>1{print $NF}'  | head -1)
         # This condition passes in 2 conditions:

--- a/.github/workflows/update-backlog-atlas.yml
+++ b/.github/workflows/update-backlog-atlas.yml
@@ -19,6 +19,10 @@ env:
   BACKLOG_ATLAS_PIP: backlog-atlas==0.16
   BACKLOG_ATLAS_BRANCH: backlog-atlas
 
+concurrency:
+  group: update-backlog-atlas
+  cancel-in-progress: true
+
 jobs:
   ensure-backlog-branch:
     runs-on: ubuntu-latest
@@ -49,9 +53,6 @@ jobs:
 
   process:
     needs: ensure-backlog-branch
-    concurrency:
-      group: update-backlog-atlas
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

Cancel superseded Core tests, CodeQL, website, and Backlog Atlas runs so
obsolete work does not consume the Hydra Ecosystem organization's limited
hosted-runner concurrency.

Stop CodeQL from scanning generated gh-pages output, restrict website pull
request builds to website-affecting paths, and apply Backlog Atlas
concurrency at workflow scope so setup work is canceled too.

Preserve the full Python and OS test matrix and the existing
deploy_website_hydra force-deploy path.
