### PR TITLE
Remove redundant setup-xcode step from macOS CI

### DIFF
--- a/.github/actions/macos/action.yml
+++ b/.github/actions/macos/action.yml
@@ -12,9 +12,6 @@ runs:
       path: |-
         ~/miniconda3
         ~/Library/Caches/Homebrew
-  - uses: maxim-lobanov/setup-xcode@v1.6.0
-    with:
-      xcode-version: latest-stable
   - name: Preparing environment - Conda
     run: |-
       if [[ -f ~/miniconda3/LICENSE.txt ]] ; then


### PR DESCRIPTION
Closes #3369.

The macOS composite action selected `latest-stable` Xcode through `maxim-lobanov/setup-xcode@v1.6.0`. Hydra never invokes the Xcode toolchain, so the step does nothing for the macOS jobs and keeps a third-party action on the Actions allowlist for no reason.

## Verification

**1. Nothing in the tree touches the toolchain.** No reference to `xcodebuild`, `xcrun`, `clang`, `DEVELOPER_DIR`, `CFLAGS`, `LDFLAGS` or `MACOSX_DEPLOYMENT_TARGET` in any workflow, script, or Python file, and no `ext_modules`/`Extension(...)` anywhere — nothing compiles native code.

**2. Nothing compiles at install time.** On macOS arm64 with Python 3.14 (the newest version in the `test_macos` matrix, so the most likely to be missing wheels), every dependency resolved to a prebuilt wheel:

```
Using cached pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl (173 kB)
Downloading omegaconf-2.4.0.dev15-py3-none-any.whl (246 kB)
```

The compiler is never invoked, so the selected Xcode version cannot matter.

**3. The test suite passes without any Xcode selection.** Ran the core tests on macOS 15 (arm64) with `DEVELOPER_DIR` unset, i.e. the plain runner default that applies once this step is gone:

```
2237 passed in 58.12s
```

That excludes `tests/test_completion.py`, which fails in my local shell for an unrelated reason (`tests/scripts/test_bash_install_uninstall.sh: line 18: python: command not found` — the conda env on CI provides `python`, my login shell only has `python3`). Nothing in those failures relates to Xcode.

Worth noting for reviewers: removing the step does not remove a compiler. `setup-xcode` only *selects* among the Xcode versions already on the runner image by setting `DEVELOPER_DIR`; without it the image default stays active, and Command Line Tools still provide `clang`. So even a future dependency that needs to build from source would still build.

The two callers of this action — the `test_macos` matrix in `core_tests.yml` and the macOS leg of release validation in `prepare-release.yml` — are unchanged, and both should be watched on this PR as the issue asks.