### PR TITLE
Install Backlog Atlas from backlog_atlas-0.17-0.g9000fdf0e2a2-py3-none-any.whl

### DIFF
--- a/.github/backlog-atlas/manifest.json
+++ b/.github/backlog-atlas/manifest.json
@@ -21,12 +21,18 @@
       "optional": true,
       "path": ".github/backlog-atlas/atlas.yaml",
       "remove": "clean"
+    },
+    {
+      "branch": "backlog-atlas",
+      "path": ".backlog-atlas/packages/backlog_atlas-0.17-0.g9000fdf0e2a2-py3-none-any.whl",
+      "remove": "uninstall"
     }
   ],
   "install": {
-    "install_source": "backlog-atlas==0.16",
-    "installed_version": "0.16",
-    "source_type": "pypi",
+    "bundled_wheel_path": ".backlog-atlas/packages/backlog_atlas-0.17-0.g9000fdf0e2a2-py3-none-any.whl",
+    "install_source": "backlog-atlas-branch/.backlog-atlas/packages/backlog_atlas-0.17-0.g9000fdf0e2a2-py3-none-any.whl",
+    "installed_version": "0.17",
+    "source_type": "bundled-wheel",
     "workflow_path": ".github/workflows/update-backlog-atlas.yml"
   },
   "schema_version": 1,

--- a/.github/workflows/update-backlog-atlas.yml
+++ b/.github/workflows/update-backlog-atlas.yml
@@ -6,6 +6,8 @@ on:
     types: [opened, closed, labeled, unlabeled, reopened]
   pull_request:
     types: [opened, closed, labeled, unlabeled, reopened]
+  pull_request_target:
+    types: [closed]
   schedule:
     - cron: '0 7 * * *'  # daily fallback
   workflow_dispatch:
@@ -16,15 +18,17 @@ permissions:
   pull-requests: read
 
 env:
-  BACKLOG_ATLAS_PIP: backlog-atlas==0.16
+  BACKLOG_ATLAS_PIP: backlog-atlas-branch/.backlog-atlas/packages/backlog_atlas-0.17-0.g9000fdf0e2a2-py3-none-any.whl
   BACKLOG_ATLAS_BRANCH: backlog-atlas
-
-concurrency:
-  group: update-backlog-atlas
-  cancel-in-progress: true
 
 jobs:
   ensure-backlog-branch:
+    if: >-
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      (github.event_name != 'pull_request_target' ||
+      (github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name != github.repository))
     runs-on: ubuntu-latest
     steps:
       - name: Ensure Backlog Atlas branch exists
@@ -53,6 +57,21 @@ jobs:
 
   process:
     needs: ensure-backlog-branch
+    if: >-
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      (github.event_name != 'pull_request_target' ||
+      (github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name != github.repository))
+    concurrency:
+      group: >-
+        ${{ ((github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository) &&
+        (github.event_name != 'pull_request_target' ||
+        (github.event.pull_request.merged == true &&
+        github.event.pull_request.head.repo.full_name != github.repository))) &&
+        'update-backlog-atlas-writable' || 'update-backlog-atlas-unwritable' }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -101,7 +120,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git rm --ignore-unmatch BACKLOG.md BACKLOG-UPDATES.md
-          git add .backlog-atlas last_snapshot.json backlog.json updates.jsonl index.html favicon.svg
+          git add .backlog-atlas last_snapshot.json backlog.json updates.jsonl index.html favicon.svg badge.svg
           if [ -f atlas.json ]; then
             git add atlas.json
           else


### PR DESCRIPTION
Adds the Backlog Atlas workflow.

Installs Backlog Atlas 0.17 from bundled wheel .backlog-atlas/packages/backlog_atlas-0.17-0.g9000fdf0e2a2-py3-none-any.whl.

Install source: `backlog-atlas-branch/.backlog-atlas/packages/backlog_atlas-0.17-0.g9000fdf0e2a2-py3-none-any.whl`