### PR TITLE
Backlog Atlas canary: trusted event

### DIFF
--- a/.github/backlog-atlas-canary/trusted.txt
+++ b/.github/backlog-atlas-canary/trusted.txt
@@ -1,0 +1,1 @@
+Backlog Atlas canary: trusted same-repository event. Safe to delete.


### PR DESCRIPTION
Controlled same-repository event for Backlog Atlas fork-safety verification. This PR will be closed without merging.\n\nCloses #3385