### PR TITLE
Backlog Atlas canary: external fork event

### DIFF
--- a/.github/backlog-atlas-canary/external.txt
+++ b/.github/backlog-atlas-canary/external.txt
@@ -1,0 +1,1 @@
+Backlog Atlas canary: external-fork event. Safe to delete.


### PR DESCRIPTION
Controlled external-fork event for Backlog Atlas fork-safety verification. Contains only a disposable marker and will be retargeted before merge.\n\nCloses #3386