### PR TITLE
Install Backlog Atlas 0.18

### DIFF
--- a/.github/backlog-atlas/manifest.json
+++ b/.github/backlog-atlas/manifest.json
@@ -23,16 +23,16 @@
       "remove": "clean"
     },
     {
-      "branch": "backlog-atlas",
-      "path": ".backlog-atlas/packages/backlog_atlas-0.17-0.g9000fdf0e2a2-py3-none-any.whl",
+      "branch": "default",
+      "optional": true,
+      "path": ".github/workflows/temporary-backlog-atlas-upgrade-cleanup.yml",
       "remove": "uninstall"
     }
   ],
   "install": {
-    "bundled_wheel_path": ".backlog-atlas/packages/backlog_atlas-0.17-0.g9000fdf0e2a2-py3-none-any.whl",
-    "install_source": "backlog-atlas-branch/.backlog-atlas/packages/backlog_atlas-0.17-0.g9000fdf0e2a2-py3-none-any.whl",
-    "installed_version": "0.17",
-    "source_type": "bundled-wheel",
+    "install_source": "backlog-atlas==0.18",
+    "installed_version": "0.18",
+    "source_type": "pypi",
     "workflow_path": ".github/workflows/update-backlog-atlas.yml"
   },
   "schema_version": 1,

--- a/.github/workflows/temporary-backlog-atlas-upgrade-cleanup.yml
+++ b/.github/workflows/temporary-backlog-atlas-upgrade-cleanup.yml
@@ -1,0 +1,98 @@
+name: Backlog Atlas Upgrade Cleanup
+
+on:
+  push:
+    paths:
+      - .github/workflows/update-backlog-atlas.yml
+      - .github/workflows/temporary-backlog-atlas-upgrade-cleanup.yml
+      - .github/backlog-atlas/manifest.json
+  workflow_dispatch:
+
+concurrency:
+  group: backlog-atlas-upgrade-cleanup
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  BACKLOG_ATLAS_BRANCH: backlog-atlas
+  BACKLOG_ATLAS_CLEANUP_WORKFLOW: ".github/workflows/temporary-backlog-atlas-upgrade-cleanup.yml"
+  BACKLOG_ATLAS_REMOVE_PACKAGES_JSON: '[".backlog-atlas/packages/backlog_atlas-0.17-0.g9000fdf0e2a2-py3-none-any.whl"]'
+
+jobs:
+  cleanup:
+    if: github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Remove old bundled install packages
+        run: |
+          python3 - <<'PY' > /tmp/backlog-atlas-remove-packages
+          import json
+          import os
+          from pathlib import PurePosixPath
+
+          def safe(path):
+              if not isinstance(path, str) or "\n" in path or path.startswith("/"):
+                  return False
+              parts = PurePosixPath(path).parts
+              return ".." not in parts and path not in {"", "."}
+
+          try:
+              paths = json.loads(os.environ["BACKLOG_ATLAS_REMOVE_PACKAGES_JSON"])
+          except json.JSONDecodeError:
+              paths = []
+
+          if not isinstance(paths, list):
+              paths = []
+
+          for path in dict.fromkeys(paths):
+              if (
+                  safe(path)
+                  and path.startswith(".backlog-atlas/packages/")
+                  and path.endswith(".whl")
+              ):
+                  print(path)
+          PY
+
+          if ! [ -s /tmp/backlog-atlas-remove-packages ]; then
+            echo "::notice title=Backlog Atlas upgrade cleanup::No old bundled install packages were listed."
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --heads origin "$BACKLOG_ATLAS_BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$BACKLOG_ATLAS_BRANCH"
+            git worktree add ../backlog-atlas-branch FETCH_HEAD
+            cd ../backlog-atlas-branch
+            while IFS= read -r package; do
+              if [ -z "$package" ]; then
+                  continue
+              fi
+              git rm --ignore-unmatch -- "$package"
+            done < /tmp/backlog-atlas-remove-packages
+            if git diff --cached --quiet; then
+              echo "::notice title=Backlog Atlas upgrade cleanup::No old bundled install packages were present."
+            else
+              git commit -m "backlog: remove old bundled install packages [skip ci]"
+              git push origin HEAD:"$BACKLOG_ATLAS_BRANCH"
+              echo "::notice title=Backlog Atlas upgrade cleanup::Removed old bundled install packages from $BACKLOG_ATLAS_BRANCH."
+            fi
+          else
+            echo "::notice title=Backlog Atlas upgrade cleanup::$BACKLOG_ATLAS_BRANCH branch was absent."
+          fi
+      - name: Remove temporary upgrade cleanup workflow
+        run: |
+          git rm --ignore-unmatch "$BACKLOG_ATLAS_CLEANUP_WORKFLOW"
+          if git diff --cached --quiet; then
+            echo "::notice title=Backlog Atlas upgrade cleanup::Temporary cleanup workflow was already absent."
+          else
+            git commit -m "backlog: remove temporary upgrade cleanup workflow [skip ci]"
+            git push
+          fi

--- a/.github/workflows/update-backlog-atlas.yml
+++ b/.github/workflows/update-backlog-atlas.yml
@@ -18,7 +18,7 @@ permissions:
   pull-requests: read
 
 env:
-  BACKLOG_ATLAS_PIP: backlog-atlas-branch/.backlog-atlas/packages/backlog_atlas-0.17-0.g9000fdf0e2a2-py3-none-any.whl
+  BACKLOG_ATLAS_PIP: backlog-atlas==0.18
   BACKLOG_ATLAS_BRANCH: backlog-atlas
 
 jobs:


### PR DESCRIPTION
Adds the Backlog Atlas workflow.

Installs Backlog Atlas 0.18 from backlog-atlas==0.18.

Install source: `backlog-atlas==0.18`