### PR TITLE
Backlog Atlas 0.18 external-fork smoke

### DIFF
--- a/.github/backlog-atlas-smoke/0.18-external-fork.txt
+++ b/.github/backlog-atlas-smoke/0.18-external-fork.txt
@@ -1,0 +1,1 @@
+backlog-atlas 0.18 external-fork smoke


### PR DESCRIPTION
Controlled maintainer smoke test for Backlog Atlas 0.18. The untrusted pull_request run must execute no jobs; after merge into this disposable non-default base branch, the trusted pull_request_target catch-up must update from Hydra main only. The branch and marker will be deleted after verification.