### PR TITLE
Add draft Hydra contributor agreements

### DIFF
--- a/website/src/pages/legal/entity-cla.md
+++ b/website/src/pages/legal/entity-cla.md
@@ -1,0 +1,227 @@
+---
+title: Hydra Entity Contributor License Agreement
+description: Draft entity contributor agreement for Hydra.
+draft: true
+---
+
+# DRAFT — NOT FOR SIGNATURE
+
+This review draft selects the standard Harmony Entity Contributor License
+Agreement, copyright-license form, with outbound-license Option Five. Its
+project-specific fields are filled in, but it has not completed publication
+review.
+
+# Hydra Entity Contributor License Agreement
+
+Thank you for your interest in contributing to Hydra ("We" or "Us").
+
+This contributor agreement ("Agreement") documents the rights granted by
+contributors to Us. The Entity CLA is an exceptional, manually handled path.
+Before submitting a Contribution on behalf of a Legal Entity, contact Us at
+hydra@yadan.net. If We agree to use an Entity CLA, We will provide execution
+instructions. This is a legally binding document, so please read it carefully
+before agreeing to it.
+
+## 1. Definitions
+
+"You" means any Legal Entity on behalf of whom a Contribution has been received
+by Us. "Legal Entity" means an entity which is not a natural person.
+"Affiliates" means other Legal Entities that control, are controlled by, or
+under common control with that Legal Entity. For the purposes of this
+definition, "control" means (i) the power, direct or indirect, to cause the
+direction or management of such Legal Entity, whether by contract or otherwise,
+(ii) ownership of fifty percent (50%) or more of the outstanding shares or
+securities which vote to elect the management or other persons who direct such
+Legal Entity or (iii) beneficial ownership of such entity.
+
+"Contribution" means any work of authorship that is Submitted by You to Us in
+which You own or assert ownership of the Copyright. If You do not own the
+Copyright in the entire work of authorship, You must follow Section 3(d).
+
+"Copyright" means all rights protecting works of authorship owned or controlled
+by You or Your Affiliates, including copyright, moral and neighboring rights,
+as appropriate, for the full term of their existence including any extensions
+by You.
+
+"Material" means the work of authorship which is made available by Us to third
+parties. The Material means the Hydra work of authorship to which the
+Contribution was Submitted. After You Submit the Contribution, it may be
+included in the Material.
+
+"Submit" means any form of electronic, verbal, or written communication sent to
+Us or our representatives, including but not limited to electronic mailing
+lists, source code control systems, and issue tracking systems that are managed
+by, or on behalf of, Us for the purpose of discussing and improving the
+Material, but excluding communication that is conspicuously marked or otherwise
+designated in writing by You as "Not a Contribution."
+
+"Submission Date" means the date on which You Submit a Contribution to Us.
+
+"Effective Date" means the date You execute this Agreement or the date You
+first Submit a Contribution to Us, whichever is earlier.
+
+## 2. Grant of Rights
+
+### 2.1 Copyright License
+
+(a) You retain ownership of the Copyright in Your Contribution and have the
+same rights to use or license the Contribution which You would have had without
+entering into the Agreement.
+
+(b) To the maximum extent permitted by the relevant law, You grant to Us a
+perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable
+license under the Copyright covering the Contribution, with the right to
+sublicense such rights through multiple tiers of sublicensees, to reproduce,
+modify, display, perform and distribute the Contribution as part of the
+Material; provided that this license is conditioned upon compliance with
+Section 2.3.
+
+(c) To the maximum extent permitted by law, You knowingly and expressly waive
+Your right under Section 180.5 of the Intellectual Property Code of the
+Philippines to receive regular statements of accounts from Us concerning the
+Contribution or the licenses granted by this Agreement. You acknowledge that
+the licenses granted by this Agreement are royalty-free and that We will not
+provide such statements.
+
+### 2.2 Patent License
+
+For patent claims including, without limitation, method, process, and apparatus
+claims which You or Your Affiliates own, control or have the right to grant, now
+or in the future, You grant to Us a perpetual, worldwide, non-exclusive,
+transferable, royalty-free, irrevocable patent license, with the right to
+sublicense these rights to multiple tiers of sublicensees, to make, have made,
+use, sell, offer for sale, import and otherwise transfer the Contribution and
+the Contribution in combination with the Material (and portions of such
+combination). This license is granted only to the extent that the exercise of
+the licensed rights infringes such patent claims; and provided that this license
+is conditioned upon compliance with Section 2.3.
+
+### 2.3 Outbound License — Option Five
+
+Based on the grant of rights in Sections 2.1 and 2.2, if We include Your
+Contribution in a Material, We may license the Contribution under any license,
+including copyleft, permissive, commercial, or proprietary licenses. As a
+condition on the exercise of this right, We agree to also license the
+Contribution under the terms of the license or licenses which We are using for
+the Material on the Submission Date.
+
+### 2.4 Moral Rights
+
+If moral rights apply to the Contribution, to the maximum extent permitted by
+law, You waive and agree not to assert such moral rights against Us or our
+successors in interest, or any of our licensees, either direct or indirect.
+
+### 2.5 Our Rights
+
+You acknowledge that We are not obligated to use Your Contribution as part of
+the Material and may decide to include any Contribution We consider
+appropriate.
+
+### 2.6 Reservation of Rights
+
+Any rights not expressly licensed under this section are expressly reserved by
+You.
+
+## 3. Agreement
+
+You confirm that:
+
+(a) You have the legal authority to enter into this Agreement.
+
+(b) You or Your Affiliates own the Copyright and patent claims covering the
+Contribution which are required to grant the rights under Section 2.
+
+(c) The grant of rights under Section 2 does not violate any grant of rights
+which You or Your Affiliates have made to third parties.
+
+(d) If a work You Submit contains material whose Copyright You do not own, You
+must identify that material conspicuously in the Submission and provide its
+source, its owner if known, and its applicable license. You must not Submit the
+material unless its applicable license or other authorization permits You to do
+so. Material identified under this paragraph is not licensed by You under this
+Agreement. We may require its removal or further evidence of authorization.
+
+## 4. Disclaimer
+
+EXCEPT FOR THE EXPRESS WARRANTIES IN SECTION 3, THE CONTRIBUTION IS PROVIDED
+"AS IS". MORE PARTICULARLY, ALL EXPRESS OR IMPLIED WARRANTIES INCLUDING,
+WITHOUT LIMITATION, ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE EXPRESSLY DISCLAIMED BY YOU TO
+US. TO THE EXTENT THAT ANY SUCH WARRANTIES CANNOT BE DISCLAIMED, SUCH WARRANTY
+IS LIMITED IN DURATION TO THE MINIMUM PERIOD PERMITTED BY LAW.
+
+## 5. Consequential Damage Waiver
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL YOU BE
+LIABLE FOR ANY LOSS OF PROFITS, LOSS OF ANTICIPATED SAVINGS, LOSS OF DATA,
+INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL AND EXEMPLARY DAMAGES ARISING OUT
+OF THIS AGREEMENT REGARDLESS OF THE LEGAL OR EQUITABLE THEORY (CONTRACT, TORT OR
+OTHERWISE) UPON WHICH THE CLAIM IS BASED.
+
+## 6. Miscellaneous
+
+### 6.1
+
+This Agreement will be governed by and construed in accordance with the laws of
+the Republic of the Philippines excluding its conflicts of law provisions.
+Under certain circumstances, the governing law in this section might be
+superseded by the United Nations Convention on Contracts for the International
+Sale of Goods ("UN Convention") and the parties intend to avoid the
+application of the UN Convention to this Agreement and, thus, exclude the
+application of the UN Convention in its entirety to this Agreement.
+
+### 6.2
+
+This Agreement sets out the entire agreement between You and Us for Your
+Contributions to Us and overrides all other agreements or understandings.
+
+### 6.3
+
+If You or We assign the rights or obligations received through this Agreement
+to a third party, as a condition of the assignment, that third party must agree
+in writing to abide by all the rights and obligations in the Agreement.
+
+### 6.4
+
+The failure of either party to require performance by the other party of any
+provision of this Agreement in one situation shall not affect the right of a
+party to require such performance at any time in the future. A waiver of
+performance under a provision in one situation shall not be considered a waiver
+of the performance of the provision in the future or a waiver of the provision
+in its entirety.
+
+### 6.5
+
+If any provision of this Agreement is found void and unenforceable, such
+provision will be replaced to the extent possible with a provision that comes
+closest to the meaning of the original provision and which is enforceable. The
+terms and conditions set forth in this Agreement shall apply notwithstanding
+any failure of essential purpose of this Agreement or any limited remedy to the
+maximum extent possible under law.
+
+## Parties
+
+You:
+
+- Legal entity name: recorded in the executed agreement
+- Jurisdiction of organization: recorded in the executed agreement
+- Registered address: recorded in the executed agreement
+- Authorized signatory and title: recorded in the executed agreement
+- Signatory email address: recorded in the executed agreement
+- Agreement version, signature, and execution date: recorded in the executed
+  agreement
+
+Us:
+
+- Name: Omry Yadan
+- Title: Hydra project steward
+- Contact: hydra@yadan.net
+
+---
+
+Adapted from the Harmony Entity Contributor License Agreement, Version 1.0,
+July 4, 2011, licensed under the Creative Commons Attribution 3.0 Unported
+License. The copyright-license form and standard Option Five were selected,
+project scope was narrowed to Hydra, and project-specific execution and
+third-party-material instructions were added. This draft has not been approved
+for signature.

--- a/website/src/pages/legal/individual-cla.md
+++ b/website/src/pages/legal/individual-cla.md
@@ -1,0 +1,228 @@
+---
+title: Hydra Individual Contributor License Agreement
+description: Draft individual contributor agreement for Hydra.
+draft: true
+---
+
+# DRAFT — NOT FOR SIGNATURE
+
+This review draft selects the standard Harmony Individual Contributor License
+Agreement, copyright-license form, with outbound-license Option Five. Its
+project-specific fields are filled in, but it has not completed the signing
+service pilot or publication review.
+
+# Hydra Individual Contributor License Agreement
+
+> **Before proceeding:** Most contributors should sign this Individual CLA. If
+> you are employed, obtain your employer's approval before signing. Employment
+> does not automatically require an Entity CLA—an agreement signed by a company,
+> university, nonprofit, or other organization. If your employer does not
+> approve, do not sign or contribute. If your employer wants to contribute to
+> Hydra, contact the Hydra maintainers about an Entity CLA. Entity CLAs are
+> handled manually, may take additional time, and must use Hydra's standard
+> agreement; Hydra generally will not negotiate alternative terms. You must be
+> at least eighteen years old to sign this Individual CLA.
+
+Thank you for your interest in contributing to Hydra ("We" or "Us").
+
+This contributor agreement ("Agreement") documents the rights granted by
+contributors to Us. To make this document effective, accept it electronically
+through the SAP-hosted CLA Assistant workflow linked from a Hydra pull request.
+CLA Assistant authenticates Your GitHub account and records Your acceptance of
+the displayed agreement version. This is a legally binding document, so please
+read it carefully before agreeing to it.
+
+## 1. Definitions
+
+"You" means the individual who Submits a Contribution to Us.
+
+"Contribution" means any work of authorship that is Submitted by You to Us in
+which You own or assert ownership of the Copyright. If You do not own the
+Copyright in the entire work of authorship, You must follow Section 3(d).
+
+"Copyright" means all rights protecting works of authorship owned or controlled
+by You, including copyright, moral and neighboring rights, as appropriate, for
+the full term of their existence including any extensions by You.
+
+"Material" means the work of authorship which is made available by Us to third
+parties. The Material means the Hydra work of authorship to which the
+Contribution was Submitted. After You Submit the Contribution, it may be
+included in the Material.
+
+"Submit" means any form of electronic, verbal, or written communication sent to
+Us or our representatives, including but not limited to electronic mailing
+lists, source code control systems, and issue tracking systems that are managed
+by, or on behalf of, Us for the purpose of discussing and improving the
+Material, but excluding communication that is conspicuously marked or otherwise
+designated in writing by You as "Not a Contribution."
+
+"Submission Date" means the date on which You Submit a Contribution to Us.
+
+"Effective Date" means the date You execute this Agreement or the date You
+first Submit a Contribution to Us, whichever is earlier.
+
+## 2. Grant of Rights
+
+### 2.1 Copyright License
+
+(a) You retain ownership of the Copyright in Your Contribution and have the
+same rights to use or license the Contribution which You would have had without
+entering into the Agreement.
+
+(b) To the maximum extent permitted by the relevant law, You grant to Us a
+perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable
+license under the Copyright covering the Contribution, with the right to
+sublicense such rights through multiple tiers of sublicensees, to reproduce,
+modify, display, perform and distribute the Contribution as part of the
+Material; provided that this license is conditioned upon compliance with
+Section 2.3.
+
+(c) To the maximum extent permitted by law, You knowingly and expressly waive
+Your right under Section 180.5 of the Intellectual Property Code of the
+Philippines to receive regular statements of accounts from Us concerning the
+Contribution or the licenses granted by this Agreement. You acknowledge that
+the licenses granted by this Agreement are royalty-free and that We will not
+provide such statements.
+
+### 2.2 Patent License
+
+For patent claims including, without limitation, method, process, and apparatus
+claims which You own, control or have the right to grant, now or in the future,
+You grant to Us a perpetual, worldwide, non-exclusive, transferable,
+royalty-free, irrevocable patent license, with the right to sublicense these
+rights to multiple tiers of sublicensees, to make, have made, use, sell, offer
+for sale, import and otherwise transfer the Contribution and the Contribution
+in combination with the Material (and portions of such combination). This
+license is granted only to the extent that the exercise of the licensed rights
+infringes such patent claims; and provided that this license is conditioned
+upon compliance with Section 2.3.
+
+### 2.3 Outbound License — Option Five
+
+Based on the grant of rights in Sections 2.1 and 2.2, if We include Your
+Contribution in a Material, We may license the Contribution under any license,
+including copyleft, permissive, commercial, or proprietary licenses. As a
+condition on the exercise of this right, We agree to also license the
+Contribution under the terms of the license or licenses which We are using for
+the Material on the Submission Date.
+
+### 2.4 Moral Rights
+
+If moral rights apply to the Contribution, to the maximum extent permitted by
+law, You waive and agree not to assert such moral rights against Us or our
+successors in interest, or any of our licensees, either direct or indirect.
+
+### 2.5 Our Rights
+
+You acknowledge that We are not obligated to use Your Contribution as part of
+the Material and may decide to include any Contribution We consider
+appropriate.
+
+### 2.6 Reservation of Rights
+
+Any rights not expressly licensed under this section are expressly reserved by
+You.
+
+## 3. Agreement
+
+You confirm that:
+
+(a) You have the legal authority to enter into this Agreement.
+
+(b) You own the Copyright and patent claims covering the Contribution which
+are required to grant the rights under Section 2.
+
+(c) The grant of rights under Section 2 does not violate any grant of rights
+which You have made to third parties, including Your employer. If You are an
+employee, You have had Your employer approve this Agreement or sign the Entity
+version of this document. You are at least eighteen years old.
+
+(d) If a work You Submit contains material whose Copyright You do not own, You
+must identify that material conspicuously in the Submission and provide its
+source, its owner if known, and its applicable license. You must not Submit the
+material unless its applicable license or other authorization permits You to do
+so. Material identified under this paragraph is not licensed by You under this
+Agreement. We may require its removal or further evidence of authorization.
+
+## 4. Disclaimer
+
+EXCEPT FOR THE EXPRESS WARRANTIES IN SECTION 3, THE CONTRIBUTION IS PROVIDED
+"AS IS". MORE PARTICULARLY, ALL EXPRESS OR IMPLIED WARRANTIES INCLUDING,
+WITHOUT LIMITATION, ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE EXPRESSLY DISCLAIMED BY YOU TO
+US. TO THE EXTENT THAT ANY SUCH WARRANTIES CANNOT BE DISCLAIMED, SUCH WARRANTY
+IS LIMITED IN DURATION TO THE MINIMUM PERIOD PERMITTED BY LAW.
+
+## 5. Consequential Damage Waiver
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL YOU BE
+LIABLE FOR ANY LOSS OF PROFITS, LOSS OF ANTICIPATED SAVINGS, LOSS OF DATA,
+INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL AND EXEMPLARY DAMAGES ARISING OUT
+OF THIS AGREEMENT REGARDLESS OF THE LEGAL OR EQUITABLE THEORY (CONTRACT, TORT OR
+OTHERWISE) UPON WHICH THE CLAIM IS BASED.
+
+## 6. Miscellaneous
+
+### 6.1
+
+This Agreement will be governed by and construed in accordance with the laws of
+the Republic of the Philippines excluding its conflicts of law provisions.
+Under certain circumstances, the governing law in this section might be
+superseded by the United Nations Convention on Contracts for the International
+Sale of Goods ("UN Convention") and the parties intend to avoid the
+application of the UN Convention to this Agreement and, thus, exclude the
+application of the UN Convention in its entirety to this Agreement.
+
+### 6.2
+
+This Agreement sets out the entire agreement between You and Us for Your
+Contributions to Us and overrides all other agreements or understandings.
+
+### 6.3
+
+If You or We assign the rights or obligations received through this Agreement
+to a third party, as a condition of the assignment, that third party must agree
+in writing to abide by all the rights and obligations in the Agreement.
+
+### 6.4
+
+The failure of either party to require performance by the other party of any
+provision of this Agreement in one situation shall not affect the right of a
+party to require such performance at any time in the future. A waiver of
+performance under a provision in one situation shall not be considered a waiver
+of the performance of the provision in the future or a waiver of the provision
+in its entirety.
+
+### 6.5
+
+If any provision of this Agreement is found void and unenforceable, such
+provision will be replaced to the extent possible with a provision that comes
+closest to the meaning of the original provision and which is enforceable. The
+terms and conditions set forth in this Agreement shall apply notwithstanding
+any failure of essential purpose of this Agreement or any limited remedy to the
+maximum extent possible under law.
+
+## Parties
+
+You:
+
+- Full legal name: recorded by CLA Assistant
+- GitHub identity: recorded by CLA Assistant
+- Email address: recorded by CLA Assistant
+- Confirmation that You are at least eighteen: recorded by CLA Assistant
+- Agreement version and acceptance time: recorded by CLA Assistant
+
+Us:
+
+- Name: Omry Yadan
+- Title: Hydra project steward
+- Contact: hydra@yadan.net
+
+---
+
+Adapted from the Harmony Individual Contributor License Agreement, Version
+1.0, July 4, 2011, licensed under the Creative Commons Attribution 3.0 Unported
+License. The copyright-license form and standard Option Five were selected,
+project scope was narrowed to Hydra, and project-specific signing and
+third-party-material instructions were added. This draft has not been approved
+for signature.

--- a/website/src/pages/legal/privacy.md
+++ b/website/src/pages/legal/privacy.md
@@ -1,6 +1,7 @@
 ---
 title: Privacy policy
 description: How the Hydra website handles visitor information.
+slug: /privacy
 ---
 
 # Privacy policy


### PR DESCRIPTION

Place the individual and entity CLA drafts under the website legal pages and keep them excluded from production pending rollout validation. Move the privacy policy alongside them while preserving its public URL.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydra-ecosystem/hydra/pull/3390).
* #3391
* __->__ #3390