### PR TITLE
Adopt project-controlled Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,2 +1,26 @@
 # Code of Conduct
-Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.fb.com/codeofconduct) so that you can understand what actions will and will not be tolerated.
+
+Hydra contributors and participants are expected to behave professionally and
+treat others with respect.
+
+The following behavior is not acceptable in Hydra project spaces:
+
+- Harassment, threats, intimidation, or discrimination.
+- Insults, personal attacks, or sustained disruption.
+- Unsolicited advertising, scams, repetitive messages, or irrelevant
+  promotional content.
+- Unwelcome sexual attention or sexualized language or imagery.
+- Publishing another person's private information without permission.
+- Other conduct that would reasonably be considered inappropriate in a
+  professional setting.
+
+This policy applies in Hydra repositories, discussions, issue trackers, and
+other project spaces, as well as when someone officially represents Hydra.
+
+Report violations privately to the Hydra project steward at
+[hydra@yadan.net](mailto:hydra@yadan.net). Reports will be reviewed fairly and
+kept confidential to the extent reasonably possible.
+
+The project steward may remove content, issue a warning, temporarily restrict
+participation, or permanently ban a participant when necessary to protect the
+project and its community.

--- a/news/3394.docs
+++ b/news/3394.docs
@@ -1,0 +1,1 @@
+Adopt a project-controlled Code of Conduct and reporting address.

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -176,8 +176,7 @@ Ask questions on github or StackOverflow (Use the tag #fb-hydra):
 * [github](https://github.com/hydra-ecosystem/hydra/discussions)
 * [StackOverflow](https://stackoverflow.com/questions/tagged/fb-hydra)
 
-Follow Hydra on Twitter and Facebook:
-* [Facebook page](https://www.facebook.com/Hydra-Framework-109364473802509/)
+Follow Hydra on Twitter:
 * [Twitter](https://twitter.com/Hydra_Framework)
 
 


### PR DESCRIPTION

Replace the Facebook-hosted conduct policy with a concise Hydra policy and publish hydra@yadan.net for private reports. Remove the inactive Facebook page from current documentation.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydra-ecosystem/hydra/pull/3394).
* __->__ #3394
* #3391
* #3390