### PR TITLE
Fix nested Compose API initialization

### DIFF
--- a/hydra/initialize.py
+++ b/hydra/initialize.py
@@ -16,15 +16,29 @@ from hydra.errors import HydraException
 
 
 def get_gh_backup() -> Any:
-    if GlobalHydra in Singleton._instances:
-        return copy.deepcopy(Singleton._instances[GlobalHydra])
-    return None
+    gh = Singleton._instances.get(GlobalHydra)
+    if gh is None:
+        return None
+    assert isinstance(gh, GlobalHydra)
+    if not gh.is_initialized():
+        return copy.deepcopy(gh)
+    return gh
 
 
 def restore_gh_from_backup(_gh_backup: Any) -> Any:
     Singleton._instances.pop(GlobalHydra, None)
     if _gh_backup is not None:
         Singleton._instances[GlobalHydra] = _gh_backup
+
+
+def _initialize_hydra(create_hydra: Callable[[], Any]) -> Any:
+    gh_backup = get_gh_backup()
+    try:
+        create_hydra()
+    except BaseException:
+        restore_gh_from_backup(gh_backup)
+        raise
+    return gh_backup
 
 
 class _ScopedInitializer:
@@ -79,12 +93,13 @@ class initialize:
                 calling_file=calling_file, calling_module=calling_module
             )
 
-        self._gh_backup = get_gh_backup()
-        Hydra.create_main_hydra_file_or_module(
-            calling_file=calling_file,
-            calling_module=calling_module,
-            config_path=config_path,
-            job_name=job_name,
+        self._gh_backup = _initialize_hydra(
+            lambda: Hydra.create_main_hydra_file_or_module(
+                calling_file=calling_file,
+                calling_module=calling_module,
+                config_path=config_path,
+                job_name=job_name,
+            )
         )
 
     @classmethod
@@ -141,12 +156,13 @@ class initialize_config_module:
     ):
         version.setbase(version_base)
 
-        self._gh_backup = get_gh_backup()
-        Hydra.create_main_hydra_file_or_module(
-            calling_file=None,
-            calling_module=f"{config_module}.{job_name}",
-            config_path=None,
-            job_name=job_name,
+        self._gh_backup = _initialize_hydra(
+            lambda: Hydra.create_main_hydra_file_or_module(
+                calling_file=None,
+                calling_module=f"{config_module}.{job_name}",
+                config_path=None,
+                job_name=job_name,
+            )
         )
 
     @classmethod
@@ -201,8 +217,9 @@ class initialize_config_dir:
                 "initialize_config_dir() requires an absolute config_dir as input"
             )
         csp = create_config_search_path(search_path_dir=config_dir)
-        self._gh_backup = get_gh_backup()
-        Hydra.create_main_hydra2(task_name=job_name, config_search_path=csp)
+        self._gh_backup = _initialize_hydra(
+            lambda: Hydra.create_main_hydra2(task_name=job_name, config_search_path=csp)
+        )
 
     @classmethod
     def scoped(

--- a/hydra/initialize.py
+++ b/hydra/initialize.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import copy
 import os
 from typing import Any, Callable, Optional
 
@@ -15,7 +16,9 @@ from hydra.errors import HydraException
 
 
 def get_gh_backup() -> Any:
-    return Singleton._instances.pop(GlobalHydra, None)
+    if GlobalHydra in Singleton._instances:
+        return copy.deepcopy(Singleton._instances[GlobalHydra])
+    return None
 
 
 def restore_gh_from_backup(_gh_backup: Any) -> Any:
@@ -24,14 +27,21 @@ def restore_gh_from_backup(_gh_backup: Any) -> Any:
         Singleton._instances[GlobalHydra] = _gh_backup
 
 
-def _initialize_hydra(create_hydra: Callable[[], Any]) -> Any:
-    gh_backup = get_gh_backup()
-    try:
-        create_hydra()
-    except BaseException:
-        restore_gh_from_backup(gh_backup)
-        raise
-    return gh_backup
+class _ScopedInitializer:
+    def __init__(self, create_hydra: Callable[[], Any]) -> None:
+        self._create_hydra = create_hydra
+        self._gh_backup: Any = None
+
+    def __enter__(self, *args: Any, **kwargs: Any) -> None:
+        self._gh_backup = Singleton._instances.pop(GlobalHydra, None)
+        try:
+            self._create_hydra()
+        except BaseException:
+            restore_gh_from_backup(self._gh_backup)
+            raise
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        restore_gh_from_backup(self._gh_backup)
 
 
 class initialize:
@@ -69,7 +79,35 @@ class initialize:
                 calling_file=calling_file, calling_module=calling_module
             )
 
-        self._gh_backup = _initialize_hydra(
+        self._gh_backup = get_gh_backup()
+        Hydra.create_main_hydra_file_or_module(
+            calling_file=calling_file,
+            calling_module=calling_module,
+            config_path=config_path,
+            job_name=job_name,
+        )
+
+    @classmethod
+    def scoped(
+        cls,
+        config_path: Optional[str] = None,
+        job_name: Optional[str] = None,
+        caller_stack_depth: int = 1,
+        version_base: Optional[str] = version._UNSPECIFIED_,
+    ) -> _ScopedInitializer:
+        version.setbase(version_base)
+
+        if config_path is not None and os.path.isabs(config_path):
+            raise HydraException("config_path in initialize() must be relative")
+        calling_file, calling_module = detect_calling_file_or_module_from_stack_frame(
+            caller_stack_depth + 1
+        )
+        if job_name is None:
+            job_name = detect_task_name(
+                calling_file=calling_file, calling_module=calling_module
+            )
+
+        return _ScopedInitializer(
             lambda: Hydra.create_main_hydra_file_or_module(
                 calling_file=calling_file,
                 calling_module=calling_module,
@@ -103,7 +141,24 @@ class initialize_config_module:
     ):
         version.setbase(version_base)
 
-        self._gh_backup = _initialize_hydra(
+        self._gh_backup = get_gh_backup()
+        Hydra.create_main_hydra_file_or_module(
+            calling_file=None,
+            calling_module=f"{config_module}.{job_name}",
+            config_path=None,
+            job_name=job_name,
+        )
+
+    @classmethod
+    def scoped(
+        cls,
+        config_module: str,
+        job_name: str = "app",
+        version_base: Optional[str] = version._UNSPECIFIED_,
+    ) -> _ScopedInitializer:
+        version.setbase(version_base)
+
+        return _ScopedInitializer(
             lambda: Hydra.create_main_hydra_file_or_module(
                 calling_file=None,
                 calling_module=f"{config_module}.{job_name}",
@@ -146,7 +201,24 @@ class initialize_config_dir:
                 "initialize_config_dir() requires an absolute config_dir as input"
             )
         csp = create_config_search_path(search_path_dir=config_dir)
-        self._gh_backup = _initialize_hydra(
+        self._gh_backup = get_gh_backup()
+        Hydra.create_main_hydra2(task_name=job_name, config_search_path=csp)
+
+    @classmethod
+    def scoped(
+        cls,
+        config_dir: str,
+        job_name: str = "app",
+        version_base: Optional[str] = version._UNSPECIFIED_,
+    ) -> _ScopedInitializer:
+        version.setbase(version_base)
+
+        if not os.path.isabs(config_dir):
+            raise HydraException(
+                "initialize_config_dir() requires an absolute config_dir as input"
+            )
+        csp = create_config_search_path(search_path_dir=config_dir)
+        return _ScopedInitializer(
             lambda: Hydra.create_main_hydra2(task_name=job_name, config_search_path=csp)
         )
 

--- a/hydra/initialize.py
+++ b/hydra/initialize.py
@@ -1,7 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import copy
 import os
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from hydra import version
 from hydra._internal.hydra import Hydra
@@ -16,17 +15,23 @@ from hydra.errors import HydraException
 
 
 def get_gh_backup() -> Any:
-    if GlobalHydra in Singleton._instances:
-        return copy.deepcopy(Singleton._instances[GlobalHydra])
-    else:
-        return None
+    return Singleton._instances.pop(GlobalHydra, None)
 
 
 def restore_gh_from_backup(_gh_backup: Any) -> Any:
-    if _gh_backup is None:
-        del Singleton._instances[GlobalHydra]
-    else:
+    Singleton._instances.pop(GlobalHydra, None)
+    if _gh_backup is not None:
         Singleton._instances[GlobalHydra] = _gh_backup
+
+
+def _initialize_hydra(create_hydra: Callable[[], Any]) -> Any:
+    gh_backup = get_gh_backup()
+    try:
+        create_hydra()
+    except BaseException:
+        restore_gh_from_backup(gh_backup)
+        raise
+    return gh_backup
 
 
 class initialize:
@@ -52,8 +57,6 @@ class initialize:
         caller_stack_depth: int = 1,
         version_base: Optional[str] = version._UNSPECIFIED_,
     ) -> None:
-        self._gh_backup = get_gh_backup()
-
         version.setbase(version_base)
 
         if config_path is not None and os.path.isabs(config_path):
@@ -66,11 +69,13 @@ class initialize:
                 calling_file=calling_file, calling_module=calling_module
             )
 
-        Hydra.create_main_hydra_file_or_module(
-            calling_file=calling_file,
-            calling_module=calling_module,
-            config_path=config_path,
-            job_name=job_name,
+        self._gh_backup = _initialize_hydra(
+            lambda: Hydra.create_main_hydra_file_or_module(
+                calling_file=calling_file,
+                calling_module=calling_module,
+                config_path=config_path,
+                job_name=job_name,
+            )
         )
 
     def __enter__(self, *args: Any, **kwargs: Any) -> None: ...
@@ -96,15 +101,15 @@ class initialize_config_module:
         job_name: str = "app",
         version_base: Optional[str] = version._UNSPECIFIED_,
     ):
-        self._gh_backup = get_gh_backup()
-
         version.setbase(version_base)
 
-        Hydra.create_main_hydra_file_or_module(
-            calling_file=None,
-            calling_module=f"{config_module}.{job_name}",
-            config_path=None,
-            job_name=job_name,
+        self._gh_backup = _initialize_hydra(
+            lambda: Hydra.create_main_hydra_file_or_module(
+                calling_file=None,
+                calling_module=f"{config_module}.{job_name}",
+                config_path=None,
+                job_name=job_name,
+            )
         )
 
     def __enter__(self, *args: Any, **kwargs: Any) -> None: ...
@@ -131,8 +136,6 @@ class initialize_config_dir:
         job_name: str = "app",
         version_base: Optional[str] = version._UNSPECIFIED_,
     ) -> None:
-        self._gh_backup = get_gh_backup()
-
         version.setbase(version_base)
 
         # Relative here would be interpreted as relative to cwd, which - depending on when it run
@@ -143,7 +146,9 @@ class initialize_config_dir:
                 "initialize_config_dir() requires an absolute config_dir as input"
             )
         csp = create_config_search_path(search_path_dir=config_dir)
-        Hydra.create_main_hydra2(task_name=job_name, config_search_path=csp)
+        self._gh_backup = _initialize_hydra(
+            lambda: Hydra.create_main_hydra2(task_name=job_name, config_search_path=csp)
+        )
 
     def __enter__(self, *args: Any, **kwargs: Any) -> None: ...
 

--- a/hydra/initialize.py
+++ b/hydra/initialize.py
@@ -42,20 +42,30 @@ def _initialize_hydra(create_hydra: Callable[[], Any]) -> Any:
 
 
 class _ScopedInitializer:
-    def __init__(self, create_hydra: Callable[[], Any]) -> None:
+    def __init__(
+        self, create_hydra: Callable[[], Any], version_base: Optional[str]
+    ) -> None:
         self._create_hydra = create_hydra
+        self._version_base = version_base
         self._gh_backup: Any = None
+        self._version_base_backup: Optional[str] = None
 
     def __enter__(self, *args: Any, **kwargs: Any) -> None:
         self._gh_backup = Singleton._instances.pop(GlobalHydra, None)
+        self._version_base_backup = version.getbase()
         try:
+            version.setbase(self._version_base)
             self._create_hydra()
         except BaseException:
             restore_gh_from_backup(self._gh_backup)
+            assert self._version_base_backup is not None
+            version.VersionBase.instance().setbase(self._version_base_backup)
             raise
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         restore_gh_from_backup(self._gh_backup)
+        assert self._version_base_backup is not None
+        version.VersionBase.instance().setbase(self._version_base_backup)
 
 
 class initialize:
@@ -110,8 +120,6 @@ class initialize:
         caller_stack_depth: int = 1,
         version_base: Optional[str] = version._UNSPECIFIED_,
     ) -> _ScopedInitializer:
-        version.setbase(version_base)
-
         if config_path is not None and os.path.isabs(config_path):
             raise HydraException("config_path in initialize() must be relative")
         calling_file, calling_module = detect_calling_file_or_module_from_stack_frame(
@@ -128,7 +136,8 @@ class initialize:
                 calling_module=calling_module,
                 config_path=config_path,
                 job_name=job_name,
-            )
+            ),
+            version_base,
         )
 
     def __enter__(self, *args: Any, **kwargs: Any) -> None: ...
@@ -172,15 +181,14 @@ class initialize_config_module:
         job_name: str = "app",
         version_base: Optional[str] = version._UNSPECIFIED_,
     ) -> _ScopedInitializer:
-        version.setbase(version_base)
-
         return _ScopedInitializer(
             lambda: Hydra.create_main_hydra_file_or_module(
                 calling_file=None,
                 calling_module=f"{config_module}.{job_name}",
                 config_path=None,
                 job_name=job_name,
-            )
+            ),
+            version_base,
         )
 
     def __enter__(self, *args: Any, **kwargs: Any) -> None: ...
@@ -228,15 +236,16 @@ class initialize_config_dir:
         job_name: str = "app",
         version_base: Optional[str] = version._UNSPECIFIED_,
     ) -> _ScopedInitializer:
-        version.setbase(version_base)
-
         if not os.path.isabs(config_dir):
             raise HydraException(
                 "initialize_config_dir() requires an absolute config_dir as input"
             )
         csp = create_config_search_path(search_path_dir=config_dir)
         return _ScopedInitializer(
-            lambda: Hydra.create_main_hydra2(task_name=job_name, config_search_path=csp)
+            lambda: Hydra.create_main_hydra2(
+                task_name=job_name, config_search_path=csp
+            ),
+            version_base,
         )
 
     def __enter__(self, *args: Any, **kwargs: Any) -> None: ...

--- a/news/3364.bugfix
+++ b/news/3364.bugfix
@@ -1,0 +1,2 @@
+Make Compose API initialization contexts nestable and restore an existing Hydra
+state after normal exits, initialization errors, and composition errors.

--- a/news/3364.bugfix
+++ b/news/3364.bugfix
@@ -1,2 +1,1 @@
-Make Compose API initialization contexts nestable and restore an existing Hydra
-state after normal exits, initialization errors, and composition errors.
+Add scoped Compose API initializers that can nest and restore existing Hydra state.

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -504,6 +504,14 @@ def test_method_initializers_reject_reinitialization(
     )
     persistent_hydra = GlobalHydra.instance()
 
+    class NonCopyable:
+        def __deepcopy__(self, memo: Any) -> Any:
+            raise AssertionError("initialized GlobalHydra should not be copied")
+
+    # Re-initialization must reach GlobalHydra's normal ValueError even when
+    # the existing instance contains state that cannot be deep-copied.
+    setattr(persistent_hydra, "noncopyable", NonCopyable())
+
     initializers = [
         lambda: initialize(job_name="replacement"),
         lambda: initialize_config_module(
@@ -515,6 +523,31 @@ def test_method_initializers_reject_reinitialization(
         with raises(ValueError, match="GlobalHydra is already initialized"):
             initializer()
         assert GlobalHydra.instance() is persistent_hydra
+
+
+def test_method_initializers_restore_hydra_after_initialization_error(
+    hydra_restore_singletons: Any, monkeypatch: Any, tmp_path: Path
+) -> None:
+    def fail_after_mutation(*args: Any, **kwargs: Any) -> None:
+        # Simulate an initialization failure after GlobalHydra was partially
+        # mutated, before an initializer object can be returned to its caller.
+        setattr(GlobalHydra.instance(), "hydra", object())
+        raise RuntimeError("initialization failed")
+
+    monkeypatch.setattr(Hydra, "create_main_hydra_file_or_module", fail_after_mutation)
+    monkeypatch.setattr(Hydra, "create_main_hydra2", fail_after_mutation)
+
+    initializers = [
+        lambda: initialize(job_name="failing"),
+        lambda: initialize_config_module(
+            config_module="hydra.test_utils.configs", job_name="failing"
+        ),
+        lambda: initialize_config_dir(config_dir=str(tmp_path), job_name="failing"),
+    ]
+    for initializer in initializers:
+        with raises(RuntimeError, match="initialization failed"):
+            initializer()
+        assert not GlobalHydra.instance().is_initialized()
 
 
 def test_missing_init_py_error(hydra_restore_singletons: Any) -> None:

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -20,6 +20,7 @@ from hydra import (
     version,
 )
 from hydra._internal.config_search_path_impl import ConfigSearchPathImpl
+from hydra._internal.hydra import Hydra
 from hydra.core.config_search_path import SearchPathQuery
 from hydra.core.config_store import ConfigStore
 from hydra.core.global_hydra import GlobalHydra
@@ -408,6 +409,88 @@ def test_initialize_config_module_ctx(hydra_restore_singletons: Any) -> None:
     ):
         ret = compose(return_hydra_config=True)
         assert ret.hydra.job.name == "test_job"
+
+
+def test_scoped_initializers_restore_existing_hydra(
+    hydra_restore_singletons: Any, tmp_path: Path
+) -> None:
+    initialize_config_module(
+        config_module="hydra.test_utils.configs", job_name="persistent"
+    )
+    persistent_hydra = GlobalHydra.instance()
+
+    initializers = [
+        lambda: initialize(job_name="scoped"),
+        lambda: initialize_config_module(
+            config_module="hydra.test_utils.configs", job_name="scoped"
+        ),
+        lambda: initialize_config_dir(config_dir=str(tmp_path), job_name="scoped"),
+    ]
+    for initializer in initializers:
+        with initializer():
+            assert GlobalHydra.instance() is not persistent_hydra
+            assert compose(overrides=["+scope=active"]) == {"scope": "active"}
+        assert GlobalHydra.instance() is persistent_hydra
+
+
+def test_nested_initialize_config_dir_contexts(
+    hydra_restore_singletons: Any, tmp_path: Path
+) -> None:
+    outer_dir = tmp_path / "outer"
+    inner_dir = tmp_path / "inner"
+    outer_dir.mkdir()
+    inner_dir.mkdir()
+    OmegaConf.save({"source": "outer"}, outer_dir / "config.yaml")
+    OmegaConf.save({"source": "inner"}, inner_dir / "config.yaml")
+
+    with initialize_config_dir(config_dir=str(outer_dir)):
+        outer_hydra = GlobalHydra.instance()
+        assert compose(config_name="config") == {"source": "outer"}
+
+        with initialize_config_dir(config_dir=str(inner_dir)):
+            assert GlobalHydra.instance() is not outer_hydra
+            assert compose(config_name="config") == {"source": "inner"}
+
+        assert GlobalHydra.instance() is outer_hydra
+        assert compose(config_name="config") == {"source": "outer"}
+
+    assert not GlobalHydra.instance().is_initialized()
+
+
+def test_scoped_initializer_restores_hydra_after_composition_error(
+    hydra_restore_singletons: Any,
+) -> None:
+    with initialize_config_module(
+        config_module="hydra.test_utils.configs", job_name="outer"
+    ):
+        outer_hydra = GlobalHydra.instance()
+        with raises(ConfigCompositionException):
+            with initialize_config_module(
+                config_module="hydra.test_utils.configs", job_name="inner"
+            ):
+                compose(config_name="missing_config")
+
+        assert GlobalHydra.instance() is outer_hydra
+
+
+def test_scoped_initializer_restores_hydra_after_initialization_error(
+    hydra_restore_singletons: Any, monkeypatch: Any
+) -> None:
+    initialize_config_module(
+        config_module="hydra.test_utils.configs", job_name="persistent"
+    )
+    persistent_hydra = GlobalHydra.instance()
+
+    def fail_initialization(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("initialization failed")
+
+    monkeypatch.setattr(Hydra, "create_main_hydra_file_or_module", fail_initialization)
+    with raises(RuntimeError, match="initialization failed"):
+        initialize_config_module(
+            config_module="hydra.test_utils.configs", job_name="scoped"
+        )
+
+    assert GlobalHydra.instance() is persistent_hydra
 
 
 def test_missing_init_py_error(hydra_restore_singletons: Any) -> None:

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -420,11 +420,13 @@ def test_scoped_initializers_restore_existing_hydra(
     persistent_hydra = GlobalHydra.instance()
 
     initializers = [
-        lambda: initialize(job_name="scoped"),
-        lambda: initialize_config_module(
+        lambda: initialize.scoped(job_name="scoped"),
+        lambda: initialize_config_module.scoped(
             config_module="hydra.test_utils.configs", job_name="scoped"
         ),
-        lambda: initialize_config_dir(config_dir=str(tmp_path), job_name="scoped"),
+        lambda: initialize_config_dir.scoped(
+            config_dir=str(tmp_path), job_name="scoped"
+        ),
     ]
     for initializer in initializers:
         with initializer():
@@ -447,7 +449,7 @@ def test_nested_initialize_config_dir_contexts(
         outer_hydra = GlobalHydra.instance()
         assert compose(config_name="config") == {"source": "outer"}
 
-        with initialize_config_dir(config_dir=str(inner_dir)):
+        with initialize_config_dir.scoped(config_dir=str(inner_dir)):
             assert GlobalHydra.instance() is not outer_hydra
             assert compose(config_name="config") == {"source": "inner"}
 
@@ -465,7 +467,7 @@ def test_scoped_initializer_restores_hydra_after_composition_error(
     ):
         outer_hydra = GlobalHydra.instance()
         with raises(ConfigCompositionException):
-            with initialize_config_module(
+            with initialize_config_module.scoped(
                 config_module="hydra.test_utils.configs", job_name="inner"
             ):
                 compose(config_name="missing_config")
@@ -486,11 +488,33 @@ def test_scoped_initializer_restores_hydra_after_initialization_error(
 
     monkeypatch.setattr(Hydra, "create_main_hydra_file_or_module", fail_initialization)
     with raises(RuntimeError, match="initialization failed"):
-        initialize_config_module(
+        with initialize_config_module.scoped(
             config_module="hydra.test_utils.configs", job_name="scoped"
-        )
+        ):
+            pass
 
     assert GlobalHydra.instance() is persistent_hydra
+
+
+def test_method_initializers_reject_reinitialization(
+    hydra_restore_singletons: Any, tmp_path: Path
+) -> None:
+    initialize_config_module(
+        config_module="hydra.test_utils.configs", job_name="persistent"
+    )
+    persistent_hydra = GlobalHydra.instance()
+
+    initializers = [
+        lambda: initialize(job_name="replacement"),
+        lambda: initialize_config_module(
+            config_module="hydra.test_utils.configs", job_name="replacement"
+        ),
+        lambda: initialize_config_dir(config_dir=str(tmp_path), job_name="replacement"),
+    ]
+    for initializer in initializers:
+        with raises(ValueError, match="GlobalHydra is already initialized"):
+            initializer()
+        assert GlobalHydra.instance() is persistent_hydra
 
 
 def test_missing_init_py_error(hydra_restore_singletons: Any) -> None:

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -435,6 +435,39 @@ def test_scoped_initializers_restore_existing_hydra(
         assert GlobalHydra.instance() is persistent_hydra
 
 
+def test_scoped_initializers_restore_version_base(
+    hydra_restore_singletons: Any,
+) -> None:
+    initial_version_base = version.getbase()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", Hydra15MigrationWarning)
+        outer = initialize_config_module.scoped(
+            config_module="hydra.test_utils.configs",
+            job_name="outer",
+            version_base="1.3",
+        )
+        inner = initialize_config_module.scoped(
+            config_module="hydra.test_utils.configs",
+            job_name="inner",
+            version_base="1.4",
+        )
+
+        assert version.getbase() == initial_version_base
+        with outer:
+            assert version.getbase() == "1.3"
+            assert compose(return_hydra_config=True).hydra.runtime.version_base == "1.3"
+            with inner:
+                assert version.getbase() == "1.4"
+                assert (
+                    compose(return_hydra_config=True).hydra.runtime.version_base
+                    == "1.4"
+                )
+            assert version.getbase() == "1.3"
+            assert compose(return_hydra_config=True).hydra.runtime.version_base == "1.3"
+
+        assert version.getbase() == initial_version_base
+
+
 def test_nested_initialize_config_dir_contexts(
     hydra_restore_singletons: Any, tmp_path: Path
 ) -> None:
@@ -482,18 +515,24 @@ def test_scoped_initializer_restores_hydra_after_initialization_error(
         config_module="hydra.test_utils.configs", job_name="persistent"
     )
     persistent_hydra = GlobalHydra.instance()
+    persistent_version_base = version.getbase()
 
     def fail_initialization(*args: Any, **kwargs: Any) -> None:
         raise RuntimeError("initialization failed")
 
     monkeypatch.setattr(Hydra, "create_main_hydra_file_or_module", fail_initialization)
-    with raises(RuntimeError, match="initialization failed"):
-        with initialize_config_module.scoped(
-            config_module="hydra.test_utils.configs", job_name="scoped"
-        ):
-            pass
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", Hydra15MigrationWarning)
+        with raises(RuntimeError, match="initialization failed"):
+            with initialize_config_module.scoped(
+                config_module="hydra.test_utils.configs",
+                job_name="scoped",
+                version_base="1.3",
+            ):
+                pass
 
     assert GlobalHydra.instance() is persistent_hydra
+    assert version.getbase() == persistent_version_base
 
 
 def test_method_initializers_reject_reinitialization(

--- a/website/docs/advanced/compose_api.md
+++ b/website/docs/advanced/compose_api.md
@@ -34,9 +34,10 @@ There are 3 initialization methods:
 
 All 3 can be used as methods or contexts.
 When used as methods, they are initializing Hydra globally and should only be called once.
-When used as contexts, they temporarily install their own Hydra state and restore the exact
-previous state on exit. Contexts can be used multiple times or nested, including inside an
-application where Hydra is already initialized. Callers do not need to clear `GlobalHydra`.
+The existing context form can be used multiple times when Hydra is not already initialized.
+When Hydra may already be initialized, use the initializer's `scoped()` class method. It
+temporarily installs its own Hydra state and restores the exact previous state on exit, so
+scoped contexts can be nested without callers clearing `GlobalHydra`.
 Like <b>@hydra.main()</b>, all three still accept the deprecated `version_base`
 parameter in Hydra 1.4. Remove it after upgrading; see the
 [Hydra 1.4 preparation guide](../upgrades/1.3_to_1.4/prepare_for_1_4.md).
@@ -53,7 +54,7 @@ if __name__ == "__main__":
         print(OmegaConf.to_yaml(cfg))
 
         # Nested contexts temporarily replace the enclosing configuration.
-        with initialize(config_path="other_conf", job_name="nested_app"):
+        with initialize.scoped(config_path="other_conf", job_name="nested_app"):
             nested_cfg = compose(config_name="config")
 
         # The outer context is active again here.

--- a/website/docs/advanced/compose_api.md
+++ b/website/docs/advanced/compose_api.md
@@ -34,7 +34,9 @@ There are 3 initialization methods:
 
 All 3 can be used as methods or contexts.
 When used as methods, they are initializing Hydra globally and should only be called once.
-When used as contexts, they are initializing Hydra within the context and can be used multiple times.
+When used as contexts, they temporarily install their own Hydra state and restore the exact
+previous state on exit. Contexts can be used multiple times or nested, including inside an
+application where Hydra is already initialized. Callers do not need to clear `GlobalHydra`.
 Like <b>@hydra.main()</b>, all three still accept the deprecated `version_base`
 parameter in Hydra 1.4. Remove it after upgrading; see the
 [Hydra 1.4 preparation guide](../upgrades/1.3_to_1.4/prepare_for_1_4.md).
@@ -49,6 +51,13 @@ if __name__ == "__main__":
     with initialize(config_path="conf", job_name="test_app"):
         cfg = compose(config_name="config", overrides=["db=mysql", "db.user=me"])
         print(OmegaConf.to_yaml(cfg))
+
+        # Nested contexts temporarily replace the enclosing configuration.
+        with initialize(config_path="other_conf", job_name="nested_app"):
+            nested_cfg = compose(config_name="config")
+
+        # The outer context is active again here.
+        cfg = compose(config_name="config")
 
     # global initialization
     initialize(config_path="conf", job_name="test_app")

--- a/website/docs/advanced/compose_api.md
+++ b/website/docs/advanced/compose_api.md
@@ -28,9 +28,9 @@ Doing so forfeits many of the benefits of Hydra
 
 ### Initialization methods
 There are 3 initialization methods:
-- <GithubLink to="hydra/initialize.py#L37">initialize()</GithubLink>: Initialize with a config path relative to the caller
-- <GithubLink to="hydra/initialize.py#L108">initialize_config_module()</GithubLink>: Initialize with config_module (absolute)
-- <GithubLink to="hydra/initialize.py#L143">initialize_config_dir()</GithubLink>: Initialize with a config_dir on the file system (absolute)
+- <GithubLink to="hydra/initialize.py#L71">initialize()</GithubLink>: Initialize with a config path relative to the caller
+- <GithubLink to="hydra/initialize.py#L152">initialize_config_module()</GithubLink>: Initialize with config_module (absolute)
+- <GithubLink to="hydra/initialize.py#L203">initialize_config_dir()</GithubLink>: Initialize with a config_dir on the file system (absolute)
 
 All 3 can be used as methods or contexts.
 When used as methods, they are initializing Hydra globally and should only be called once.


### PR DESCRIPTION
## Motivation

Compose API initializers currently serve both persistent method calls and context-manager calls. Because initialization happens in the constructor, the existing context form cannot distinguish a nested scope before `__enter__` and therefore rejects an already initialized `GlobalHydra`.

This change adds explicit `.scoped()` entry points to all three Compose API initializers. A scoped initializer temporarily installs its own Hydra state and restores the exact previous singleton on normal exit, composition errors, and initialization errors. Existing method-style calls keep their original behavior: the first call initializes Hydra persistently, while repeated calls raise `ValueError` without replacing the existing instance or deep-copying initialized state.

The documentation describes the explicit scoped form, and the news fragment records the behavior change.

### Have you read the Contributing Guidelines on pull requests?

Yes.

### For non-trivial features, API changes, or behavior changes: is there an issue or design discussion where maintainers agreed on the direction?

Issue #3364, opened by the maintainer, defines the expected behavior, design constraint, and acceptance criteria for separating persistent and scoped initialization.

## Test Plan

- `python -m pytest -q tests/test_compose.py` (113 passed)
- `python -m pytest -q tests --ignore=tests/test_completion.py` (2243 passed)
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest -q tests/test_completion.py` (651 passed, 73 skipped, 17 xfailed)
- `pre-commit run --files hydra/initialize.py tests/test_compose.py website/docs/advanced/compose_api.md news/3364.bugfix`
- `ruff check hydra tests` and `ruff format --check hydra tests`
- `pyrefly check hydra/initialize.py tests/test_compose.py`
- `towncrier build --draft`

Regression coverage includes all three scoped variants over existing state, nested and sequential contexts, initialization and composition failures, unchanged method-style re-initialization errors, and restoration after method-style construction failures.

## Related Issues and PRs

Closes #3364.
