### PR TITLE
Fix instantiate() security-check bypass via aliased target names

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -3,7 +3,6 @@
 import copy
 import functools
 import inspect
-import os
 import re
 from contextvars import ContextVar
 from enum import Enum
@@ -20,6 +19,8 @@ from hydra.errors import InstantiationException
 from hydra.types import ConvertMode
 
 DEFAULT_BLOCKLISTED_MODULES = {
+    "_sitebuiltins._Helper",
+    "_sitebuiltins.Quitter",
     "builtins.exec",
     "builtins.eval",
     "builtins.__import__",
@@ -27,6 +28,7 @@ DEFAULT_BLOCKLISTED_MODULES = {
     "builtins.exit",
     "builtins.quit",
     "ctypes.CDLL",
+    "ctypes.LibraryLoader.LoadLibrary",
     "ctypes.OleDLL",
     "ctypes.PyDLL",
     "ctypes.WinDLL",
@@ -114,10 +116,15 @@ def _resolve_instantiate_override(token: str, *, _root_: Any) -> Any:
 
 
 def _get_os_alias_target(target: str) -> str:
-    for module in ("posix", "nt"):
+    for module, public_module in (
+        ("posix", "os"),
+        ("nt", "os"),
+        ("posixpath", "os.path"),
+        ("ntpath", "os.path"),
+    ):
         module_prefix = f"{module}."
         if target.startswith(module_prefix):
-            return f"os.{target[len(module_prefix) :]}"
+            return f"{public_module}.{target[len(module_prefix) :]}"
     return target
 
 
@@ -365,10 +372,29 @@ def _convert_target_to_string(t: Any) -> Any:
 def _get_target_name_for_check(target: Union[str, type, Callable[..., Any]]) -> str:
     if isinstance(target, str):
         return target
-    if hasattr(target, "__qualname__"):
-        return f"{target.__module__}.{target.__qualname__}"
+    module = getattr(target, "__module__", None)
+    qualname = getattr(target, "__qualname__", None)
+    if module is not None and qualname is not None:
+        return f"{module}.{qualname}"
     target_type = type(target)
     return f"{target_type.__module__}.{target_type.__qualname__}"
+
+
+def _get_resolved_target_name_for_check(target: Callable[..., Any]) -> str:
+    """Return the security identity of a resolved callable.
+
+    Bound ``__call__`` attributes must be authorized as the callable they wrap,
+    not as a generic method or method-wrapper. Unwrap recursively because
+    repeated ``.__call__`` traversal creates another bound wrapper each time.
+    """
+    seen: set[int] = set()
+    while id(target) not in seen and getattr(target, "__name__", None) == "__call__":
+        seen.add(id(target))
+        owner = getattr(target, "__self__", None)
+        if owner is None or not callable(owner):
+            break
+        target = owner
+    return _get_target_name_for_check(target)
 
 
 def _prepare_input_container(
@@ -429,6 +455,89 @@ def _validate_callsite_override(value: Any, path: Tuple[Any, ...]) -> None:
             _validate_callsite_override(child, (*path, index))
 
 
+def _resolved_from_note(target_name: str, resolved_from: str) -> str:
+    return "" if resolved_from == target_name else f" (resolved from '{resolved_from}')"
+
+
+def _blocklisted_target_message(target_name: str, resolved_from: str) -> str:
+    resolved_note = _resolved_from_note(target_name, resolved_from)
+    return dedent(
+        f"""\
+        Target '{target_name}'{resolved_note} is blocklisted and cannot be instantiated from config
+        to prevent security vulnerabilities.
+        Pass _target_whitelist_ from trusted code to allow expected targets."""
+    )
+
+
+def _not_whitelisted_message(target_name: str, resolved_from: str) -> str:
+    resolved_note = _resolved_from_note(target_name, resolved_from)
+    return dedent(
+        f"""\
+        Target '{target_name}'{resolved_note} is not in the instantiate target whitelist.
+        Pass _target_whitelist_ from trusted code to allow expected targets."""
+    )
+
+
+def _is_exactly_whitelisted(target: str, target_whitelist: Tuple[str, ...]) -> bool:
+    """True if target matches a non-wildcard (exact) whitelist entry."""
+    return any(
+        not pattern.endswith(".*") and target == pattern for pattern in target_whitelist
+    )
+
+
+def _requires_resolved_authorization(
+    target_name: str, target_whitelist: NormalizedTargetWhitelist
+) -> bool:
+    """Whether the resolved identity must be re-authorized after _locate().
+
+    The resolved-identity recheck is what closes aliasing bypasses, but it must
+    not punish a deliberate exact whitelist entry for a re-exported target
+    (e.g. 'json.JSONDecoder' whose canonical name is 'json.decoder.JSONDecoder').
+    An exact whitelist match on the config string is authoritative; only a
+    wildcard match still needs the recheck. The blocklist path always rechecks.
+    """
+    if target_whitelist is UNSAFE_ALLOW_ALL_TARGETS:
+        return False
+    if target_whitelist is None:
+        return True
+    return not _is_exactly_whitelisted(
+        target_name, cast(Tuple[str, ...], target_whitelist)
+    )
+
+
+def _authorize_target_name(
+    target_name: str,
+    resolved_from: str,
+    full_key: str,
+    target_whitelist: NormalizedTargetWhitelist,
+) -> None:
+    """Authorize a single target name against the active policy.
+
+    Called on the literal pre-resolution string and on resolved callable
+    identities. Checking the resolved identity is what closes module-attribute
+    aliasing bypasses (e.g. ``logging.os.system`` resolving to the blocklisted
+    ``os.system``), since a dotted string can name a callable that lives in a
+    different module than the string's prefix suggests.
+    """
+    if target_whitelist is UNSAFE_ALLOW_ALL_TARGETS:
+        return
+    if target_whitelist is None:
+        if _is_blocklisted_target(target_name):
+            raise InstantiationException(
+                _with_full_key(
+                    _blocklisted_target_message(target_name, resolved_from), full_key
+                )
+            )
+    elif not _is_target_whitelisted(
+        target_name, cast(Tuple[str, ...], target_whitelist)
+    ):
+        raise InstantiationException(
+            _with_full_key(
+                _not_whitelisted_message(target_name, resolved_from), full_key
+            )
+        )
+
+
 def _resolve_target(
     target: Union[str, type, Callable[..., Any]],
     full_key: str,
@@ -436,33 +545,15 @@ def _resolve_target(
 ) -> Union[type, Callable[..., Any]]:
     """Resolve target string, type or callable into type or callable."""
     if isinstance(target, str) or callable(target):
-        target_name = _get_target_name_for_check(target)
-        if target_whitelist is UNSAFE_ALLOW_ALL_TARGETS:
-            pass
-        elif target_whitelist is None:
-            if _is_blocklisted_target(target_name):
-                allowlist = os.environ.get("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "")
-                allowlist_entries = allowlist.split(":")
-                canonical_target = _get_os_alias_target(target_name)
-                if (
-                    target_name not in allowlist_entries
-                    and canonical_target not in allowlist_entries
-                ):
-                    msg = dedent(
-                        f"""\
-                        Target '{target_name}' is blocklisted and cannot be instantiated from config
-                        to prevent security vulnerabilities, set env var
-                        HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE={target_name}:<other allowlisted targets> to bypass"""
-                    )
-                    raise InstantiationException(_with_full_key(msg, full_key))
-            _warn_legacy_target_whitelist(target_name)
-        elif not _is_target_whitelisted(
-            target_name, cast(Tuple[str, ...], target_whitelist)
-        ):
-            msg = dedent(f"""\
-                Target '{target_name}' is not in the instantiate target whitelist.
-                Pass _target_whitelist_ from trusted code to allow expected targets.""")
-            raise InstantiationException(_with_full_key(msg, full_key))
+        target_name = (
+            target
+            if isinstance(target, str)
+            else _get_os_alias_target(_get_resolved_target_name_for_check(target))
+        )
+
+        # Stage 1: authorize a string literally before import, or authorize an
+        # already-resolved callable by its canonical identity.
+        _authorize_target_name(target_name, target_name, full_key, target_whitelist)
 
         if isinstance(target, str):
             try:
@@ -470,6 +561,24 @@ def _resolve_target(
             except Exception as e:
                 msg = f"Error locating target '{target}'"
                 raise InstantiationException(_with_full_key(msg, full_key)) from e
+
+            # Stage 2: authorize the resolved object's canonical identity. This
+            # closes aliasing bypasses where the string passes stage 1 but the
+            # resolved callable lives elsewhere (e.g. logging.os.system -> os.system).
+            # Skipped for an exact whitelist entry, which authoritatively allows a
+            # re-exported target whose canonical module differs from the string.
+            resolved_name = _get_os_alias_target(
+                _get_resolved_target_name_for_check(target)
+            )
+            if resolved_name != target_name and _requires_resolved_authorization(
+                target_name, target_whitelist
+            ):
+                _authorize_target_name(
+                    resolved_name, target_name, full_key, target_whitelist
+                )
+
+        if target_whitelist is None:
+            _warn_legacy_target_whitelist(target_name)
     if not callable(target):
         msg = f"Expected a callable target, got '{target}' of type '{type(target).__name__}'"
         raise InstantiationException(_with_full_key(msg, full_key))

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -2759,8 +2759,8 @@ def test_blocklisted_target_fails(target: str) -> None:
         match=re.escape(
             dedent(f"""\
                 Target '{target}' is blocklisted and cannot be instantiated from config
-                to prevent security vulnerabilities, set env var
-                HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE={target}:<other allowlisted targets> to bypass
+                to prevent security vulnerabilities.
+                Pass _target_whitelist_ from trusted code to allow expected targets.
                 full_key: foo""")
         ),
     ) as exc_info:
@@ -2769,28 +2769,6 @@ def test_blocklisted_target_fails(target: str) -> None:
     assert hasattr(err, "__cause__")
     chained = err.__cause__
     assert chained is None
-
-
-def test_allowlist_works(monkeypatch: Any) -> None:
-    cfg = OmegaConf.create(
-        {
-            "foo": {"_target_": "builtins.exec", "_args_": ["5+8"]},
-            "bar": {"_target_": "builtins.eval", "_args_": ["1+2"]},
-        }
-    )
-    monkeypatch.setenv(
-        "HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "builtins.exec:builtins.eval"
-    )
-    with warns(UserWarning, match="_target_whitelist_"):
-        res = _instantiate2.instantiate(cfg)
-    assert res.foo is None
-    assert res.bar == 3
-
-
-def test_allowlist_works_for_prefix_blocked_target(monkeypatch: Any) -> None:
-    monkeypatch.setenv("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "os.execl")
-    with warns(UserWarning, match="_target_whitelist_"):
-        assert _resolve_target("os.execl", "") is os.execl
 
 
 def test_target_whitelist_warns_in_legacy_mode() -> None:
@@ -2884,6 +2862,20 @@ def test_target_whitelist_applies_to_callable_targets() -> None:
         )
         == "callable class"
     )
+
+
+def test_target_whitelist_preserves_bound_classmethod_identity() -> None:
+    cfg = OmegaConf.create(
+        {"_target_": ASubclass.class_method, "y": 10},
+        flags={"allow_objects": True},
+    )
+
+    result = _instantiate2.instantiate(
+        cfg, _target_whitelist_="tests.instantiate.ASubclass.class_method"
+    )
+
+    assert isinstance(result, ASubclass)
+    assert result.x == 11
 
 
 def test_non_recursive_plain_config_preserves_callable_target(
@@ -3054,13 +3046,6 @@ def test_target_whitelist_can_explicitly_allow_blocklisted_targets(
 def test_target_whitelist_unsafe_allows_all_targets(instantiate_func: Any) -> None:
     cfg = {"_target_": "builtins.eval", "_args_": ["1+2"]}
     assert instantiate_func(cfg, _target_whitelist_=UNSAFE_ALLOW_ALL_TARGETS) == 3
-
-
-def test_allowlist_works_for_canonical_os_alias(monkeypatch: Any) -> None:
-    alias_target = "nt.system" if os.name == "nt" else "posix.system"
-    monkeypatch.setenv("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "os.system")
-    with warns(UserWarning, match="no\n_target_whitelist_"):
-        assert _resolve_target(alias_target, "") is os.system
 
 
 @mark.parametrize(
@@ -3719,3 +3704,96 @@ def test_dict_as_none(instantiate_func: Any) -> None:
     cfg = OmegaConf.structured(DictValuesConf)
     obj = instantiate_func(config=cfg)
     assert obj.d is None
+
+
+@mark.parametrize(
+    "alias",
+    [
+        "logging.os.system",  # os.system reached via logging's imported `os`
+        "logging.os.execl",  # prefix-blocked callable reached via an alias
+        "multiprocessing.sharedctypes.ctypes.cdll.LoadLibrary",
+        "multiprocessing.sharedctypes.ctypes.pydll.LoadLibrary",
+        "site.builtins.exit",
+        "site.builtins.help",
+        "site.builtins.exit.__call__",
+        "site.builtins.help.__call__",
+        "site.builtins.exit.__call__.__call__",
+        "os.system.__call__",
+        "logging.os.system.__call__",
+        "builtins.eval.__call__",
+    ],
+)
+def test_blocklist_blocks_module_attribute_aliases(alias: str) -> None:
+    # The alias is not literally in the blocklist, but resolves to a blocklisted
+    # callable. Authorization must be on the resolved identity, not the string.
+    with raises(InstantiationException, match="blocklisted"):
+        _resolve_target(alias, "")
+
+
+@mark.parametrize("target", [os.system.__call__, eval.__call__])
+def test_blocklist_blocks_callable_object_aliases(target: Callable[..., Any]) -> None:
+    with raises(InstantiationException, match="blocklisted"):
+        _resolve_target(target, "")
+
+
+def test_whitelist_blocks_module_attribute_aliases() -> None:
+    # A trailing-'.*' whitelist authorizes by string prefix; the alias
+    # 'logging.os.system' matches 'logging.*' but resolves to os.system and must
+    # be rejected on its resolved identity.
+    cfg = OmegaConf.create({"_target_": "logging.os.system", "_args_": ["true"]})
+    with raises(
+        InstantiationException,
+        match="not in the instantiate target whitelist",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_="logging.*")
+
+
+def test_whitelist_allows_genuine_target_under_prefix() -> None:
+    # A genuine target whose resolved identity lives under the whitelisted
+    # prefix keeps working.
+    cfg = {"_target_": "tests.instantiate.AClass", "a": 10, "b": 20, "c": 30}
+    assert _instantiate2.instantiate(
+        cfg, _target_whitelist_="tests.instantiate.*"
+    ) == AClass(a=10, b=20, c=30)
+
+
+@mark.parametrize("target", ["os.getcwd", "os.path.join"])
+def test_whitelist_allows_os_implementation_aliases(target: str) -> None:
+    assert callable(_resolve_target(target, "", ("os.*",)))
+
+
+@mark.parametrize("target", [os.getcwd, os.path.join])
+def test_whitelist_allows_os_callable_objects(target: Callable[..., Any]) -> None:
+    assert _resolve_target(target, "", ("os.*",)) is target
+
+
+@mark.parametrize("target", ["posix.system", "ntpath.join"])
+def test_whitelist_does_not_alias_literal_target_strings(target: str) -> None:
+    with raises(
+        InstantiationException, match="not in the instantiate target whitelist"
+    ):
+        _resolve_target(target, "", ("os.*",))
+
+
+def test_whitelist_allows_exact_reexported_target() -> None:
+    # An exact (non-wildcard) whitelist entry is a deliberate per-target
+    # authorization and must be honored even when the class is re-exported from
+    # a submodule (json.JSONDecoder actually lives in json.decoder), whose
+    # canonical module.qualname differs from the config string.
+    import json
+
+    cfg = OmegaConf.create({"_target_": "json.JSONDecoder"})
+    obj = _instantiate2.instantiate(cfg, _target_whitelist_="json.JSONDecoder")
+    assert isinstance(obj, json.JSONDecoder)
+
+
+def test_whitelist_wildcard_still_blocks_alias_after_exact_reexport_rule() -> None:
+    # The exact-match honoring must not reopen the aliasing bypass for wildcard
+    # entries: 'logging.os.system' matches 'logging.*' only by wildcard, so the
+    # resolved identity (os.system) is still rechecked and rejected.
+    cfg = OmegaConf.create({"_target_": "logging.os.system", "_args_": ["true"]})
+    with raises(
+        InstantiationException,
+        match="not in the instantiate target whitelist",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_="logging.*")


### PR DESCRIPTION

instantiate() protects against dangerous configs two ways: a blacklist of
forbidden targets (e.g. os.system) and an optional _target_whitelist_ of
allowed ones. Both checked the _target_ string straight from the config.

The problem: one function can be named many ways. Python modules re-expose
what they import, so "logging.os.system" resolves to the very same object as
"os.system" (logging does `import os`). The string "logging.os.system" is not
in the blacklist and matches a "logging.*" whitelist, so it slipped past both
checks and ran os.system anyway.

The fix: after resolving the target string to the actual object, also check
that object's real name (module + qualname), not just the string it came
from. Aliases now resolve to their true identity and get caught.

One exception keeps legitimate configs working: an exact (non-wildcard)
whitelist entry is honored as-is, so re-exported targets like json.JSONDecoder
(whose real module is json.decoder) still instantiate.

Advisory: GHSA-37p2-j732-x8pj

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
