### PR TITLE
Harden instantiate() target authorization

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -3,6 +3,7 @@
 import copy
 import functools
 import inspect
+import operator
 import re
 from contextvars import ContextVar
 from enum import Enum
@@ -18,28 +19,24 @@ from hydra._internal.utils import _locate
 from hydra.errors import InstantiationException
 from hydra.types import ConvertMode
 
+# This blocklist is a best-effort, defense-in-depth stopgap that refuses the
+# most obvious dangerous _target_ values on the legacy (no _target_whitelist_)
+# path. It is NOT a security boundary and is intentionally not exhaustive.
+#
+# Known limitation - indirect dispatch: user-defined targets can invoke a
+# blocked method without ever naming it as a _target_. The method name is data,
+# not a target, so name-based blocking cannot see it. Hydra blocks the generic
+# standard-library dispatch primitives identified here, but cannot exhaustively
+# identify equivalent application wrappers. The target whitelist
+# (_target_whitelist_) is the real security boundary.
+# Generally problematic targets are refused on the legacy path, but trusted
+# Python code may authorize them with a target whitelist. Keep this set
+# for operations whose effect is fully named and bounded by the target itself.
 DEFAULT_BLOCKLISTED_MODULES = {
-    "_sitebuiltins._Helper",
     "_sitebuiltins.Quitter",
-    "builtins.exec",
-    "builtins.eval",
-    "builtins.__import__",
-    "builtins.compile",
     "builtins.exit",
     "builtins.quit",
-    "ctypes.CDLL",
-    "ctypes.LibraryLoader.LoadLibrary",
-    "ctypes.OleDLL",
-    "ctypes.PyDLL",
-    "ctypes.WinDLL",
-    "ctypes.cdll.LoadLibrary",
-    "ctypes.oledll.LoadLibrary",
-    "ctypes.pydll.LoadLibrary",
-    "ctypes.windll.LoadLibrary",
-    "importlib.import_module",
     "os.kill",
-    "os.system",
-    "os.popen",
     "os.putenv",
     "os.remove",
     "os.removedirs",
@@ -51,9 +48,6 @@ DEFAULT_BLOCKLISTED_MODULES = {
     "os.killpg",
     "os.rename",
     "os.renames",
-    "os.startfile",
-    "os.posix_spawn",
-    "os.posix_spawnp",
     "os.truncate",
     "os.replace",
     "os.unlink",
@@ -62,37 +56,213 @@ DEFAULT_BLOCKLISTED_MODULES = {
     "os.chmod",
     "os.chown",
     "os.chroot",
-    "os.fchdir",
     "os.lchflags",
     "os.lchmod",
     "os.lchown",
-    "os.getcwd",
     "os.chdir",
-    "pty.spawn",
-    "runpy.run_module",
-    "runpy.run_path",
     "shutil.rmtree",
     "shutil.move",
     "shutil.chown",
+}
+
+# These targets allow config data to select or supply executable behavior.
+# They are refused both on the legacy path and by a real target whitelist.
+# UNSAFE_ALLOW_ALL_TARGETS remains the explicit opt-out from all checks.
+UNCONTROLLED_EXECUTION_TARGETS = {
+    "_sitebuiltins._Helper",
+    "builtins.__import__",
+    "builtins.compile",
+    "builtins.eval",
+    "builtins.exec",
+    "builtins.help",
+    # Generic dispatch primitives delegate the effective callable, selected
+    # member, or operation to config data instead of naming it as _target_.
+    # Include public and canonical C-module spellings.
+    "operator.attrgetter",
+    "operator.call",
+    "operator.contains",
+    "operator.delitem",
+    "operator.getitem",
+    "operator.itemgetter",
+    "operator.methodcaller",
+    "operator.setitem",
+    "_operator.attrgetter",
+    "_operator.call",
+    "_operator.contains",
+    "_operator.delitem",
+    "_operator.getitem",
+    "_operator.itemgetter",
+    "_operator.methodcaller",
+    "_operator.setitem",
+    "ctypes.CDLL",
+    "ctypes.LibraryLoader.LoadLibrary",
+    "ctypes.OleDLL",
+    "ctypes.PyDLL",
+    "ctypes.WinDLL",
+    "ctypes.cdll.LoadLibrary",
+    "ctypes.oledll.LoadLibrary",
+    "ctypes.pydll.LoadLibrary",
+    "ctypes.windll.LoadLibrary",
+    "importlib.import_module",
+    "importlib.machinery.ExtensionFileLoader.create_module",
+    "importlib.machinery.ExtensionFileLoader.exec_module",
+    "importlib.machinery.ExtensionFileLoader.load_module",
+    "importlib.machinery.SourceFileLoader.exec_module",
+    "importlib.machinery.SourceFileLoader.load_module",
+    "importlib.machinery.SourcelessFileLoader.exec_module",
+    "importlib.machinery.SourcelessFileLoader.load_module",
+    "_frozen_importlib_external.ExtensionFileLoader.create_module",
+    "_frozen_importlib_external.ExtensionFileLoader.exec_module",
+    "_frozen_importlib_external.FileLoader.load_module",
+    "_frozen_importlib_external._LoaderBasics.exec_module",
+    "os.popen",
+    "os.posix_spawn",
+    "os.posix_spawnp",
+    "os.startfile",
+    "os.system",
+    "pty.spawn",
+    "runpy.run_module",
+    "runpy.run_path",
     "subprocess.Popen",
-    "subprocess.run",
     "subprocess.call",
     "subprocess.check_call",
     "subprocess.check_output",
     "subprocess.getoutput",
     "subprocess.getstatusoutput",
-    "builtins.help",
-    "sys.modules.ipdb",
-    "sys.modules.joblib",
-    "sys.modules.resource",
-    "sys.modules.psutil",
-    "sys.modules.tkinter",
+    "subprocess.run",
+    # Unsafe deserialization sinks. Include friendly and canonical C spellings
+    # so resolved identities such as pickle.loads -> _pickle.loads are caught.
+    "pickle.load",
+    "pickle.loads",
+    "pickle.Unpickler",
+    "pickle._load",
+    "pickle._loads",
+    "pickle._Unpickler",
+    "_pickle.load",
+    "_pickle.loads",
+    "_pickle.Unpickler",
+    "marshal.load",
+    "marshal.loads",
+    "tracemalloc.Snapshot.load",
+    "dill.load",
+    "dill.loads",
+    "cloudpickle.load",
+    "cloudpickle.loads",
+    # Exec/eval wrappers that run config-supplied strings or code objects.
+    "timeit.timeit",
+    "timeit.repeat",
+    "timeit.main",
+    "timeit.Timer.timeit",
+    "timeit.Timer.repeat",
+    "timeit.Timer.autorange",
+    "cProfile.run",
+    "cProfile.runctx",
+    "cProfile.Profile.run",
+    "cProfile.Profile.runctx",
+    "profile.run",
+    "profile.runctx",
+    "profile.Profile.run",
+    "profile.Profile.runctx",
+    "code.interact",
+    "code.InteractiveInterpreter.runsource",
+    "code.InteractiveInterpreter.runcode",
+    "code.InteractiveConsole.push",
+    # Annotation evaluators: these execute string annotations as expressions.
+    # Include compatibility and canonical spellings across Python versions.
+    "typing.ForwardRef._evaluate",
+    "typing._eval_type",
+    "typing.evaluate_forward_ref",
+    "typing.get_type_hints",
+    "annotationlib.ForwardRef._evaluate",
+    "annotationlib.ForwardRef.evaluate",
+    "annotationlib.get_annotations",
+    "optparse.Values.read_file",
+    "optparse.Values.read_module",
 }
 
-DEFAULT_BLOCKLISTED_MODULE_PREFIXES = (
+# These package families contain version-specific execution, import, debugger,
+# or unsafe loading surfaces. Prefixes make coverage version-resilient; narrow
+# inert constructors with plausible instantiate() use are excepted below.
+UNCONTROLLED_EXECUTION_TARGET_PREFIXES = (
     "os.exec",
     "os.spawn",
+    # Whole logging.config namespace: dictConfig/fileConfig and every
+    # BaseConfigurator/DictConfigurator method resolve and call config-named
+    # factories (arbitrary code) on the legacy/no-whitelist path. Block the
+    # family with one prefix instead of enumerating methods. Stopgap only; the
+    # permanent control for logging config is the target whitelist (GHSA-c3wx).
+    # Hydra's own logging calls logging.config.dictConfig directly (not via
+    # instantiate), so this does not affect it.
+    "logging.config.",
+    # doctest executes example code from docstrings/files (run_docstring_examples,
+    # testmod, testfile, DocTestRunner.run, ...). Block the family by default;
+    # inert constructors used to assemble tests are excepted below.
+    "doctest.",
+    # Whole-module deserialization/tracing machinery. shelve.* shelf classes
+    # unpickle values on access; trace.* delegates to CoverageResults which
+    # unpickles a counts file. The inert Trace constructor is excepted below.
+    "shelve.",
+    "trace.",
+    # pydoc imports/executes modules and files (importfile runs a file,
+    # safeimport imports by name). Inert documentation formatters are excepted
+    # below.
+    "pydoc.",
+    # Debugger machinery: pdb/bdb run/eval user strings (pdb.run/runeval,
+    # Pdb._getval/_getval_except/default, Bdb.run/runeval/runctx). Whole
+    # families; no legitimate instantiate() use.
+    "pdb.",
+    "bdb.",
 )
+
+# Exact legitimate constructors within otherwise denied module families. Exact
+# entries in UNCONTROLLED_EXECUTION_TARGETS still take precedence over exceptions.
+# An exception permits only the named target, not its methods or descendants.
+UNCONTROLLED_EXECUTION_TARGET_PREFIX_EXCEPTIONS = {
+    "doctest.DocTest",
+    "doctest.DocTestParser",
+    "doctest.Example",
+    "pydoc.HTMLDoc",
+    "pydoc.TextDoc",
+    "trace.Trace",
+}
+
+# These additional callables cannot be safely authorized by the target-name
+# whitelist, but retain temporary legacy compatibility while users migrate.
+# Uncontrolled-execution targets above are independently non-whitelistable and
+# blocked on the legacy path.
+LEGACY_COMPATIBLE_NON_WHITELISTABLE_TARGETS = {
+    "builtins.delattr",
+    "builtins.getattr",
+    "builtins.hasattr",
+    "builtins.object.__getattribute__",
+    "builtins.setattr",
+    "builtins.type.__getattribute__",
+    "hydra._internal.instantiate._instantiate2.instantiate",
+}
+
+# These targets resolve another object from a config-controlled dotpath. The
+# selected path is itself an authorization boundary, independent of whether the
+# helper is called immediately or returned through Hydra-native partial support.
+DISCOVERY_TARGETS = {
+    # Underlying resolver used by the public helpers. Gate it independently so
+    # a broad hydra.* whitelist cannot authorize an arbitrary import path.
+    "hydra._internal.utils._locate",
+    "hydra.utils.get_class",
+    "hydra.utils.get_method",
+    # get_static_method is currently an alias of get_method; list it explicitly
+    # so gating does not depend on that aliasing implementation detail.
+    "hydra.utils.get_static_method",
+    "hydra.utils.get_object",
+}
+
+# These targets may return a callable selected by config data. Non-callable
+# results remain ordinary values; callable results must independently satisfy
+# the active target policy before they can flow into another config target.
+CALLABLE_RESULT_TARGETS = {
+    "builtins.getattr",
+    "functools.partial",
+}
+DEFERRED_CALLABLE_SELECTION_TARGETS = DISCOVERY_TARGETS | CALLABLE_RESULT_TARGETS
 
 
 class _UnsafeAllowAllTargets:
@@ -149,10 +319,35 @@ def _is_target(x: Any) -> bool:
 
 def _is_blocklisted_target(target: str) -> bool:
     canonical_target = _get_os_alias_target(target)
-    return (
+    if (
         canonical_target in DEFAULT_BLOCKLISTED_MODULES
-        or canonical_target.startswith(DEFAULT_BLOCKLISTED_MODULE_PREFIXES)
-    )
+        or canonical_target in UNCONTROLLED_EXECUTION_TARGETS
+    ):
+        return True
+    if canonical_target in UNCONTROLLED_EXECUTION_TARGET_PREFIX_EXCEPTIONS:
+        return False
+    return canonical_target.startswith(UNCONTROLLED_EXECUTION_TARGET_PREFIXES)
+
+
+def _is_non_whitelistable_target(target: str) -> bool:
+    canonical_target = _get_os_alias_target(target)
+    if (
+        canonical_target in UNCONTROLLED_EXECUTION_TARGETS
+        or canonical_target in LEGACY_COMPATIBLE_NON_WHITELISTABLE_TARGETS
+    ):
+        return True
+    if canonical_target in UNCONTROLLED_EXECUTION_TARGET_PREFIX_EXCEPTIONS:
+        return False
+    return canonical_target.startswith(UNCONTROLLED_EXECUTION_TARGET_PREFIXES)
+
+
+def _is_uncontrolled_execution_target(target: str) -> bool:
+    canonical_target = _get_os_alias_target(target)
+    if canonical_target in UNCONTROLLED_EXECUTION_TARGETS:
+        return True
+    if canonical_target in UNCONTROLLED_EXECUTION_TARGET_PREFIX_EXCEPTIONS:
+        return False
+    return canonical_target.startswith(UNCONTROLLED_EXECUTION_TARGET_PREFIXES)
 
 
 def _validate_target_whitelist_pattern(pattern: Any) -> str:
@@ -222,7 +417,9 @@ class _TargetWhitelistPolicy:
     ) -> None:
         self.whitelist = whitelist
         self.reset = reset
-        self._tokens: List[Any] = []
+        self._tokens: ContextVar[Tuple[Any, ...]] = ContextVar(
+            "hydra_instantiate_target_whitelist_tokens", default=()
+        )
 
     def resolve(
         self, inherited: NormalizedTargetWhitelist
@@ -232,13 +429,16 @@ class _TargetWhitelistPolicy:
         return _combine_target_whitelists(inherited, self.whitelist)
 
     def __enter__(self) -> "_TargetWhitelistPolicy":
-        self._tokens.append(
-            _TARGET_WHITELIST_CONTEXT.set(self.resolve(_TARGET_WHITELIST_CONTEXT.get()))
+        token = _TARGET_WHITELIST_CONTEXT.set(
+            self.resolve(_TARGET_WHITELIST_CONTEXT.get())
         )
+        self._tokens.set((*self._tokens.get(), token))
         return self
 
     def __exit__(self, *args: Any) -> None:
-        _TARGET_WHITELIST_CONTEXT.reset(self._tokens.pop())
+        tokens = self._tokens.get()
+        _TARGET_WHITELIST_CONTEXT.reset(tokens[-1])
+        self._tokens.set(tokens[:-1])
 
 
 TargetWhitelist = Union[
@@ -311,6 +511,25 @@ def _warn_legacy_target_whitelist(target: str) -> None:
     )
 
 
+def _warn_direct_functools_partial_target() -> None:
+    stacklevel = 1
+    frame = inspect.currentframe()
+    while frame is not None:
+        if frame.f_code.co_filename != __file__:
+            break
+        stacklevel += 1
+        frame = frame.f_back
+    deprecation_warning(
+        dedent(
+            """\
+            Using '_target_: functools.partial' is deprecated. Set '_target_' to
+            the effective callable and use '_partial_: true' instead. Direct
+            functools.partial targets will become an error in Hydra 1.5."""
+        ),
+        stacklevel=stacklevel,
+    )
+
+
 def _extract_pos_args(input_args: Any, kwargs: Any) -> Tuple[Any, Any]:
     config_args = kwargs.pop(_Keys.ARGS, ())
     output_args = config_args
@@ -336,6 +555,7 @@ def _call_target(
     args: Tuple[Any, ...],
     kwargs: Dict[str, Any],
     full_key: str,
+    target_whitelist: NormalizedTargetWhitelist,
 ) -> Any:
     """Call target (type) with args and kwargs."""
     try:
@@ -347,10 +567,47 @@ def _call_target(
         )
         raise InstantiationException(_with_full_key(msg, full_key)) from e
 
+    resolved_target_name = _get_resolved_target_name_for_check(_target_)
+    if (
+        _partial_
+        and resolved_target_name in DEFERRED_CALLABLE_SELECTION_TARGETS
+        and target_whitelist is not None
+        and target_whitelist is not UNSAFE_ALLOW_ALL_TARGETS
+    ):
+        msg = dedent(
+            f"""\
+            Target '{resolved_target_name}' cannot use '_partial_: true' with the
+            instantiate target whitelist because its effective callable could be
+            selected after authorization. Resolve the callable immediately or use a
+            trusted Python wrapper."""
+        )
+        raise InstantiationException(_with_full_key(msg, full_key))
+
+    discovery_path = _authorize_discovery_path(
+        _target_, args, kwargs, full_key, target_whitelist
+    )
+    # For a deferred discovery partial on the legacy path, eagerly resolve and
+    # blocklist-check the selected target so a partial cannot smuggle a blocked
+    # callable past the stopgap. UNSAFE_ALLOW_ALL_TARGETS opts out of all checks
+    # and keeps discovery fully deferred.
+    if (
+        discovery_path is not None
+        and _partial_
+        and target_whitelist is not UNSAFE_ALLOW_ALL_TARGETS
+    ):
+        try:
+            discovered = _locate(discovery_path)
+        except Exception as e:
+            msg = f"Error locating discovered target '{discovery_path}'"
+            raise InstantiationException(_with_full_key(msg, full_key)) from e
+        if callable(discovered):
+            _authorize_discovery_result(
+                discovery_path, discovered, full_key, target_whitelist
+            )
     try:
         if _partial_:
             return functools.partial(_target_, *args, **kwargs)
-        return _target_(*args, **kwargs)
+        result = _target_(*args, **kwargs)
     except Exception as e:
         if _partial_:
             msg = (
@@ -360,6 +617,34 @@ def _call_target(
         else:
             msg = f"Error in call to target '{_convert_target_to_string(_target_)}':\n{repr(e)}"
         raise InstantiationException(_with_full_key(msg, full_key)) from e
+
+    if discovery_path is not None and callable(result):
+        _authorize_discovery_result(discovery_path, result, full_key, target_whitelist)
+    if resolved_target_name == "builtins.getattr" and callable(result):
+        _authorize_callable_result(
+            result, resolved_target_name, full_key, target_whitelist
+        )
+    if resolved_target_name == "functools.partial" and isinstance(
+        result, functools.partial
+    ):
+        if (
+            target_whitelist is not UNSAFE_ALLOW_ALL_TARGETS
+            and type(result) is not functools.partial
+        ):
+            msg = dedent(
+                """\
+                Direct functools.partial targets cannot construct partial subclasses
+                because overrides can hide their invocation behavior. Set '_target_'
+                to the effective callable and use '_partial_: true' instead."""
+            )
+            raise InstantiationException(_with_full_key(msg, full_key))
+        _authorize_callable_result(
+            functools.partial.func.__get__(result),
+            resolved_target_name,
+            full_key,
+            target_whitelist,
+        )
+    return result
 
 
 def _convert_target_to_string(t: Any) -> Any:
@@ -383,17 +668,42 @@ def _get_target_name_for_check(target: Union[str, type, Callable[..., Any]]) -> 
 def _get_resolved_target_name_for_check(target: Callable[..., Any]) -> str:
     """Return the security identity of a resolved callable.
 
-    Bound ``__call__`` attributes must be authorized as the callable they wrap,
-    not as a generic method or method-wrapper. Unwrap recursively because
-    repeated ``.__call__`` traversal creates another bound wrapper each time.
+    Bound ``__call__`` attributes, ``functools.partial`` objects, and unbound
+    descriptors owned by denied operator types must be authorized as the
+    callable they wrap or expose, not as generic callable containers. Unwrap
+    recursively because either wrapper form can wrap the other.
     """
     seen: set[int] = set()
-    while id(target) not in seen and getattr(target, "__name__", None) == "__call__":
+    while id(target) not in seen:
         seen.add(id(target))
-        owner = getattr(target, "__self__", None)
-        if owner is None or not callable(owner):
-            break
-        target = owner
+        if getattr(target, "__name__", None) == "__call__":
+            owner = getattr(target, "__self__", None)
+            if owner is not None and callable(owner):
+                target = owner
+                continue
+        if isinstance(target, functools.partial):
+            target = target.func
+            continue
+        break
+    if target is object.__getattribute__:
+        return "builtins.object.__getattribute__"
+    if target is type.__getattribute__:
+        return "builtins.type.__getattribute__"
+    descriptor_owner = getattr(target, "__objclass__", None)
+    if descriptor_owner is operator.attrgetter:
+        return "operator.attrgetter"
+    if descriptor_owner is operator.itemgetter:
+        return "operator.itemgetter"
+    if descriptor_owner is operator.methodcaller:
+        return "operator.methodcaller"
+    if target is functools.partial.__new__:
+        return "functools.partial"
+    if target is operator.attrgetter.__new__:
+        return "operator.attrgetter"
+    if target is operator.itemgetter.__new__:
+        return "operator.itemgetter"
+    if target is operator.methodcaller.__new__:
+        return "operator.methodcaller"
     return _get_target_name_for_check(target)
 
 
@@ -461,6 +771,40 @@ def _resolved_from_note(target_name: str, resolved_from: str) -> str:
 
 def _blocklisted_target_message(target_name: str, resolved_from: str) -> str:
     resolved_note = _resolved_from_note(target_name, resolved_from)
+    if target_name in {
+        "operator.attrgetter",
+        "operator.call",
+        "operator.contains",
+        "operator.delitem",
+        "operator.getitem",
+        "operator.itemgetter",
+        "operator.methodcaller",
+        "operator.setitem",
+        "_operator.attrgetter",
+        "_operator.call",
+        "_operator.contains",
+        "_operator.delitem",
+        "_operator.getitem",
+        "_operator.itemgetter",
+        "_operator.methodcaller",
+        "_operator.setitem",
+    }:
+        return dedent(
+            f"""\
+            Target '{target_name}'{resolved_note} is blocklisted because it performs
+            generic selection or dispatch using config data.
+            Set '_target_' to the intended callable instead. Pass
+            UNSAFE_ALLOW_ALL_TARGETS only to explicitly disable target safety checks."""
+        )
+    if _is_uncontrolled_execution_target(target_name):
+        return dedent(
+            f"""\
+            Target '{target_name}'{resolved_note} is blocklisted because it allows
+            config data to control executable behavior or belongs to an
+            execution-capable target family. It cannot be authorized with a target
+            whitelist. Pass UNSAFE_ALLOW_ALL_TARGETS only to explicitly disable
+            target safety checks."""
+        )
     return dedent(
         f"""\
         Target '{target_name}'{resolved_note} is blocklisted and cannot be instantiated from config
@@ -476,6 +820,90 @@ def _not_whitelisted_message(target_name: str, resolved_from: str) -> str:
         Target '{target_name}'{resolved_note} is not in the instantiate target whitelist.
         Pass _target_whitelist_ from trusted code to allow expected targets."""
     )
+
+
+def _non_whitelistable_target_message(target_name: str, resolved_from: str) -> str:
+    resolved_note = _resolved_from_note(target_name, resolved_from)
+    if target_name in {
+        "builtins.delattr",
+        "builtins.getattr",
+        "builtins.hasattr",
+        "builtins.object.__getattribute__",
+        "builtins.setattr",
+        "builtins.type.__getattribute__",
+    }:
+        return dedent(
+            f"""\
+            Target '{target_name}'{resolved_note} cannot be authorized by the instantiate
+            target whitelist because attribute operations can execute descriptor code before
+            the operation can be authorized. Access or mutate the attribute from trusted
+            Python code instead."""
+        )
+    if target_name == "hydra._internal.instantiate._instantiate2.instantiate":
+        return dedent(
+            f"""\
+            Target '{target_name}'{resolved_note} cannot be authorized by the instantiate
+            target whitelist because reentrant instantiate calls do not safely inherit
+            the effective whitelist. Call instantiate() from trusted Python code instead."""
+        )
+    if target_name in {
+        "operator.attrgetter",
+        "operator.call",
+        "operator.contains",
+        "operator.delitem",
+        "operator.getitem",
+        "operator.itemgetter",
+        "operator.methodcaller",
+        "operator.setitem",
+        "_operator.attrgetter",
+        "_operator.call",
+        "_operator.contains",
+        "_operator.delitem",
+        "_operator.getitem",
+        "_operator.itemgetter",
+        "_operator.methodcaller",
+        "_operator.setitem",
+    }:
+        return dedent(
+            f"""\
+            Target '{target_name}'{resolved_note} cannot be authorized by the instantiate
+            target whitelist because it performs generic selection or dispatch using
+            config data.
+            Set '_target_' to the intended callable instead."""
+        )
+    if _is_uncontrolled_execution_target(target_name):
+        return dedent(
+            f"""\
+            Target '{target_name}'{resolved_note} cannot be authorized by the
+            instantiate target whitelist because it allows config data to control
+            executable behavior or belongs to an execution-capable target family.
+            Call a narrow trusted wrapper from config instead."""
+        )
+    return dedent(
+        f"""\
+        Target '{target_name}'{resolved_note} cannot be authorized by the instantiate
+        target whitelist because it delegates the effective operation to config data.
+        Set '_target_' to the intended callable instead."""
+    )
+
+
+def _reject_non_whitelistable_target(
+    target_name: str,
+    resolved_from: str,
+    full_key: str,
+    target_whitelist: NormalizedTargetWhitelist,
+) -> None:
+    if (
+        target_whitelist is not None
+        and target_whitelist is not UNSAFE_ALLOW_ALL_TARGETS
+        and _is_non_whitelistable_target(target_name)
+    ):
+        raise InstantiationException(
+            _with_full_key(
+                _non_whitelistable_target_message(target_name, resolved_from),
+                full_key,
+            )
+        )
 
 
 def _is_exactly_whitelisted(target: str, target_whitelist: Tuple[str, ...]) -> bool:
@@ -521,6 +949,9 @@ def _authorize_target_name(
     """
     if target_whitelist is UNSAFE_ALLOW_ALL_TARGETS:
         return
+    _reject_non_whitelistable_target(
+        target_name, resolved_from, full_key, target_whitelist
+    )
     if target_whitelist is None:
         if _is_blocklisted_target(target_name):
             raise InstantiationException(
@@ -536,6 +967,51 @@ def _authorize_target_name(
                 _not_whitelisted_message(target_name, resolved_from), full_key
             )
         )
+
+
+def _authorize_discovery_path(
+    target: Callable[..., Any],
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+    full_key: str,
+    target_whitelist: NormalizedTargetWhitelist,
+) -> Optional[str]:
+    """Authorize the dotpath consumed by a Hydra discovery helper."""
+    target_name = _get_resolved_target_name_for_check(target)
+    if target_name not in DISCOVERY_TARGETS:
+        return None
+
+    path = args[0] if args else kwargs.get("path")
+    if not isinstance(path, str):
+        return None
+    _authorize_target_name(path, path, full_key, target_whitelist)
+    return path
+
+
+def _authorize_discovery_result(
+    path: str,
+    result: Callable[..., Any],
+    full_key: str,
+    target_whitelist: NormalizedTargetWhitelist,
+) -> None:
+    """Recheck a discovered callable by its canonical security identity."""
+    resolved_name = _get_os_alias_target(_get_resolved_target_name_for_check(result))
+    _reject_non_whitelistable_target(resolved_name, path, full_key, target_whitelist)
+    if resolved_name != path and _requires_resolved_authorization(
+        path, target_whitelist
+    ):
+        _authorize_target_name(resolved_name, path, full_key, target_whitelist)
+
+
+def _authorize_callable_result(
+    result: Callable[..., Any],
+    resolved_from: str,
+    full_key: str,
+    target_whitelist: NormalizedTargetWhitelist,
+) -> None:
+    """Authorize a callable selected as another target's runtime result."""
+    resolved_name = _get_os_alias_target(_get_resolved_target_name_for_check(result))
+    _authorize_target_name(resolved_name, resolved_from, full_key, target_whitelist)
 
 
 def _resolve_target(
@@ -555,6 +1031,7 @@ def _resolve_target(
         # already-resolved callable by its canonical identity.
         _authorize_target_name(target_name, target_name, full_key, target_whitelist)
 
+        resolved_name = target_name
         if isinstance(target, str):
             try:
                 target = _locate(target)
@@ -570,6 +1047,9 @@ def _resolve_target(
             resolved_name = _get_os_alias_target(
                 _get_resolved_target_name_for_check(target)
             )
+            _reject_non_whitelistable_target(
+                resolved_name, target_name, full_key, target_whitelist
+            )
             if resolved_name != target_name and _requires_resolved_authorization(
                 target_name, target_whitelist
             ):
@@ -577,6 +1057,8 @@ def _resolve_target(
                     resolved_name, target_name, full_key, target_whitelist
                 )
 
+        if resolved_name == "functools.partial":
+            _warn_direct_functools_partial_target()
         if target_whitelist is None:
             _warn_legacy_target_whitelist(target_name)
     if not callable(target):
@@ -1222,7 +1704,9 @@ def instantiate_node(
                     )
                     kwargs[key] = _convert_node(value, convert)
 
-            return _call_target(_target_, partial, args, kwargs, full_key)
+            return _call_target(
+                _target_, partial, args, kwargs, full_key, target_whitelist
+            )
         else:
             object_type = node._metadata.object_type
             if isinstance(overrides, DictConfig):

--- a/news/3411.bugfix
+++ b/news/3411.bugfix
@@ -1,0 +1,2 @@
+``instantiate()`` blocks unsafe targets and refuses to whitelist
+config-controlled execution surfaces.

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -1,9 +1,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import asyncio
 import copy
 import inspect
+import operator
 import os
 import pickle
 import re
+import warnings
 from dataclasses import InitVar, dataclass, field
 from functools import partial
 from textwrap import dedent
@@ -68,6 +71,68 @@ from tests.instantiate import (
     partial_equal,
     recisinstance,
 )
+
+operator_attrgetter = operator.attrgetter
+operator_itemgetter = operator.itemgetter
+operator_methodcaller = operator.methodcaller
+object_getattribute = object.__getattribute__
+type_getattribute = type.__getattribute__
+builtin_delattr = delattr
+builtin_hasattr = hasattr
+builtin_setattr = setattr
+
+
+class GetattrDescriptorProbe:
+    descriptor_accessed = False
+    descriptor_deleted = False
+    descriptor_set = False
+
+    @property
+    def payload(self) -> int:
+        type(self).descriptor_accessed = True
+        return 10
+
+    @payload.setter
+    def payload(self, value: int) -> None:
+        type(self).descriptor_set = True
+
+    @payload.deleter
+    def payload(self) -> None:
+        type(self).descriptor_deleted = True
+
+
+class GetattributeMeta(type):
+    descriptor_accessed = False
+
+    @property
+    def payload(cls) -> int:
+        type(cls).descriptor_accessed = True
+        return 10
+
+
+class GetattributeTypeProbe(metaclass=GetattributeMeta):
+    pass
+
+
+class ItemOperationProbe:
+    item_accessed = False
+    item_deleted = False
+    item_set = False
+    membership_checked = False
+
+    def __getitem__(self, key: str) -> int:
+        type(self).item_accessed = True
+        return 10
+
+    def __setitem__(self, key: str, value: int) -> None:
+        type(self).item_set = True
+
+    def __delitem__(self, key: str) -> None:
+        type(self).item_deleted = True
+
+    def __contains__(self, item: object) -> bool:
+        type(self).membership_checked = True
+        return False
 
 
 @fixture(
@@ -2737,7 +2802,6 @@ def test_cannot_locate_target(instantiate_func: Any) -> None:
         "ctypes.windll.LoadLibrary",
         "importlib.import_module",
         "os.execl",
-        "os.getcwd",
         "os.popen",
         "os.posix_spawn",
         "posix.kill",
@@ -2756,13 +2820,7 @@ def test_blocklisted_target_fails(target: str) -> None:
     cfg = OmegaConf.create({"foo": {"_target_": target}})
     with raises(
         InstantiationException,
-        match=re.escape(
-            dedent(f"""\
-                Target '{target}' is blocklisted and cannot be instantiated from config
-                to prevent security vulnerabilities.
-                Pass _target_whitelist_ from trusted code to allow expected targets.
-                full_key: foo""")
-        ),
+        match=rf"Target '{re.escape(target)}'.*blocklisted",
     ) as exc_info:
         _instantiate2.instantiate(cfg)
     err = exc_info.value
@@ -2771,10 +2829,95 @@ def test_blocklisted_target_fails(target: str) -> None:
     assert chained is None
 
 
+@mark.parametrize(
+    "target",
+    [
+        "importlib.machinery.ExtensionFileLoader.create_module",
+        "importlib.machinery.ExtensionFileLoader.exec_module",
+        "importlib.machinery.ExtensionFileLoader.load_module",
+        "importlib.machinery.SourceFileLoader.exec_module",
+        "importlib.machinery.SourceFileLoader.load_module",
+        "importlib.machinery.SourcelessFileLoader.exec_module",
+        "importlib.machinery.SourcelessFileLoader.load_module",
+        "_frozen_importlib_external.ExtensionFileLoader.create_module",
+        "_frozen_importlib_external.ExtensionFileLoader.exec_module",
+        "_frozen_importlib_external.FileLoader.load_module",
+        "_frozen_importlib_external._LoaderBasics.exec_module",
+    ],
+)
+def test_importlib_loader_execution_targets_are_blocklisted(target: str) -> None:
+    with (
+        warnings.catch_warnings(),
+        raises(InstantiationException, match="blocklisted"),
+    ):
+        warnings.simplefilter("ignore")
+        _instantiate2.instantiate({"_target_": target})
+
+
+@mark.parametrize(
+    "target",
+    [
+        "importlib.machinery.SourceFileLoader.load_module",
+        "_frozen_importlib_external.FileLoader.load_module",
+    ],
+)
+def test_importlib_source_loader_is_blocked_before_execution(
+    target: str, tmp_path: Any
+) -> None:
+    source = tmp_path / "payload.py"
+    marker = tmp_path / "executed"
+    source.write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('executed')\n"
+    )
+    cfg = {
+        "_target_": target,
+        "_args_": [
+            {
+                "_target_": "importlib.machinery.SourceFileLoader",
+                "_args_": ["hydra_loader_payload", str(source)],
+            }
+        ],
+    }
+
+    with (
+        warnings.catch_warnings(),
+        raises(InstantiationException, match="blocklisted"),
+    ):
+        warnings.simplefilter("ignore")
+        _instantiate2.instantiate(cfg)
+
+    assert not marker.exists()
+
+
 def test_target_whitelist_warns_in_legacy_mode() -> None:
     cfg = {"_target_": "tests.instantiate.AClass", "a": 10, "b": 20, "c": 30}
     with warns(UserWarning, match=r"This\s+warning will become an error in Hydra 1\.5"):
         assert _instantiate2.instantiate(cfg) == AClass(a=10, b=20, c=30)
+
+
+def test_direct_functools_partial_target_warns_in_legacy_mode() -> None:
+    cfg = {"_target_": "functools.partial", "_args_": [pow], "exp": 2}
+
+    with warns(UserWarning) as records:
+        factory = _instantiate2.instantiate(cfg)
+
+    assert factory(3) == 9
+    assert any(
+        "Using '_target_: functools.partial' is deprecated" in str(record.message)
+        and "use '_partial_: true' instead" in str(record.message)
+        for record in records
+    )
+
+
+def test_direct_functools_partial_target_warns_with_unsafe_allow_all() -> None:
+    cfg = {"_target_": "functools.partial", "_args_": [pow], "exp": 2}
+
+    with warns(UserWarning, match=r"Using '_target_: functools\.partial'"):
+        factory = _instantiate2.instantiate(
+            cfg, _target_whitelist_=UNSAFE_ALLOW_ALL_TARGETS
+        )
+
+    assert factory(3) == 9
 
 
 def test_target_whitelist_warning_points_to_user_callsite() -> None:
@@ -2971,6 +3114,32 @@ def test_target_whitelist_context_reset_replaces_outer_context() -> None:
         assert _instantiate2.instantiate(cfg) == AClass(a=10, b=20, c=30)
 
 
+def test_target_whitelist_policy_isolates_overlapping_async_contexts() -> None:
+    policy = target_whitelist("tests.instantiate.AClass")
+    first_entered = asyncio.Event()
+    second_entered = asyncio.Event()
+    first_exited = asyncio.Event()
+
+    async def first() -> None:
+        try:
+            with policy:
+                first_entered.set()
+                await second_entered.wait()
+        finally:
+            first_exited.set()
+
+    async def second() -> None:
+        await first_entered.wait()
+        with policy:
+            second_entered.set()
+            await first_exited.wait()
+
+    async def run() -> None:
+        await asyncio.gather(first(), second())
+
+    asyncio.run(run())
+
+
 def test_target_whitelist_policy_can_be_passed_to_instantiate(
     instantiate_func: Any,
 ) -> None:
@@ -3039,8 +3208,919 @@ def test_target_whitelist_in_config_is_rejected(instantiate_func: Any) -> None:
 def test_target_whitelist_can_explicitly_allow_blocklisted_targets(
     instantiate_func: Any,
 ) -> None:
-    cfg = {"_target_": "builtins.eval", "_args_": ["1+2"]}
-    assert instantiate_func(cfg, _target_whitelist_="builtins.eval") == 3
+    assert _instantiate2._is_blocklisted_target("_sitebuiltins.Quitter")
+    assert not _instantiate2._is_non_whitelistable_target("_sitebuiltins.Quitter")
+    cfg = {
+        "_target_": "_sitebuiltins.Quitter",
+        "_args_": ["probe", None],
+    }
+    result = instantiate_func(cfg, _target_whitelist_="_sitebuiltins.Quitter")
+    assert type(result).__module__ == "_sitebuiltins"
+    assert type(result).__qualname__ == "Quitter"
+
+
+@mark.parametrize("target", sorted(_instantiate2.UNCONTROLLED_EXECUTION_TARGETS))
+def test_uncontrolled_execution_targets_cannot_be_whitelisted(target: str) -> None:
+    assert _instantiate2._is_blocklisted_target(target)
+    assert _instantiate2._is_non_whitelistable_target(target)
+    cfg = {"_target_": target}
+
+    with raises(InstantiationException, match="cannot be authorized"):
+        _instantiate2.instantiate(cfg, _target_whitelist_=target)
+
+
+@mark.parametrize(
+    "target",
+    [
+        "os.execl",
+        "os.spawnl",
+        "logging.config.valid_ident",
+        "doctest.OutputChecker",
+        "shelve.open",
+        "trace.main",
+        "pydoc.cram",
+        "pdb.help",
+        "bdb.Bdb",
+    ],
+)
+def test_uncontrolled_execution_families_cannot_be_whitelisted(target: str) -> None:
+    assert _instantiate2._is_blocklisted_target(target)
+    assert _instantiate2._is_non_whitelistable_target(target)
+    with raises(InstantiationException, match="cannot be authorized"):
+        _instantiate2.instantiate({"_target_": target}, _target_whitelist_=target)
+
+
+def test_getcwd_is_not_blocklisted() -> None:
+    with warns(UserWarning, match="with no\n_target_whitelist_"):
+        assert _instantiate2.instantiate({"_target_": "os.getcwd"}) == os.getcwd()
+
+    assert (
+        _instantiate2.instantiate(
+            {"_target_": "os.getcwd"}, _target_whitelist_="os.getcwd"
+        )
+        == os.getcwd()
+    )
+
+
+def test_ineffective_sys_modules_entries_are_not_in_policy() -> None:
+    for target in (
+        "sys.modules.ipdb",
+        "sys.modules.joblib",
+        "sys.modules.resource",
+        "sys.modules.psutil",
+        "sys.modules.tkinter",
+    ):
+        assert target not in _instantiate2.DEFAULT_BLOCKLISTED_MODULES
+        assert target not in _instantiate2.UNCONTROLLED_EXECUTION_TARGETS
+
+
+def test_blocklist_policy_sections_are_disjoint() -> None:
+    assert _instantiate2.DEFAULT_BLOCKLISTED_MODULES.isdisjoint(
+        _instantiate2.UNCONTROLLED_EXECUTION_TARGETS
+    )
+
+
+@mark.parametrize(
+    "target",
+    [
+        "operator.call",
+        "operator.contains",
+        "operator.delitem",
+        "operator.attrgetter",
+        "operator.getitem",
+        "operator.itemgetter",
+        "operator.methodcaller",
+        "operator.setitem",
+        "_operator.call",
+        "_operator.contains",
+        "_operator.delitem",
+        "_operator.attrgetter",
+        "_operator.getitem",
+        "_operator.itemgetter",
+        "_operator.methodcaller",
+        "_operator.setitem",
+    ],
+)
+def test_operator_dispatch_targets_are_blocklisted(target: str) -> None:
+    with raises(InstantiationException, match="blocklisted"):
+        _instantiate2.instantiate({"_target_": target})
+
+
+@mark.parametrize(
+    "target",
+    [
+        "operator.call",
+        "operator.contains",
+        "operator.delitem",
+        "operator.attrgetter",
+        "operator.getitem",
+        "operator.itemgetter",
+        "operator.methodcaller",
+        "operator.setitem",
+        "_operator.call",
+        "_operator.contains",
+        "_operator.delitem",
+        "_operator.attrgetter",
+        "_operator.getitem",
+        "_operator.itemgetter",
+        "_operator.methodcaller",
+        "_operator.setitem",
+    ],
+)
+def test_target_whitelist_cannot_authorize_operator_dispatch(target: str) -> None:
+    with raises(
+        InstantiationException,
+        match=r"generic selection or dispatch using\s+config data",
+    ):
+        _instantiate2.instantiate({"_target_": target}, _target_whitelist_=target)
+
+
+@mark.parametrize(
+    ("target", "target_whitelist"),
+    [
+        (
+            "operator.methodcaller.__new__",
+            "operator.methodcaller.__new__",
+        ),
+        ("operator.methodcaller.__new__", "operator.*"),
+        (
+            "operator.methodcaller.__new__.__call__",
+            "operator.methodcaller.__new__.__call__",
+        ),
+        (
+            "tests.instantiate.test_instantiate.operator_methodcaller.__new__",
+            "tests.instantiate.test_instantiate.operator_methodcaller.__new__",
+        ),
+    ],
+)
+def test_target_whitelist_cannot_authorize_methodcaller_constructor(
+    target: str, target_whitelist: str
+) -> None:
+    with raises(
+        InstantiationException,
+        match=r"Target 'operator\.methodcaller'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate(
+            {"_target_": target}, _target_whitelist_=target_whitelist
+        )
+
+
+def test_target_whitelist_rejects_methodcaller_constructor_callable() -> None:
+    with raises(
+        InstantiationException,
+        match=r"Target 'operator\.methodcaller'.*cannot be authorized",
+    ):
+        _resolve_target(
+            operator.methodcaller.__new__,
+            full_key="",
+            target_whitelist=("operator.methodcaller",),
+        )
+
+
+def test_methodcaller_constructor_alias_is_blocklisted() -> None:
+    with raises(
+        InstantiationException,
+        match=r"Target 'operator\.methodcaller'.*resolved from.*blocklisted",
+    ):
+        _instantiate2.instantiate({"_target_": "operator.methodcaller.__new__"})
+
+
+@mark.parametrize(
+    ("target", "target_whitelist"),
+    [
+        ("operator.attrgetter.__new__", "operator.attrgetter.__new__"),
+        ("operator.attrgetter.__new__", "operator.*"),
+        (
+            "operator.attrgetter.__new__.__call__",
+            "operator.attrgetter.__new__.__call__",
+        ),
+        (
+            "tests.instantiate.test_instantiate.operator_attrgetter.__new__",
+            "tests.instantiate.test_instantiate.operator_attrgetter.__new__",
+        ),
+    ],
+)
+def test_target_whitelist_cannot_authorize_attrgetter_constructor(
+    target: str, target_whitelist: str
+) -> None:
+    with raises(
+        InstantiationException,
+        match=r"Target 'operator\.attrgetter'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate(
+            {"_target_": target}, _target_whitelist_=target_whitelist
+        )
+
+
+def test_target_whitelist_rejects_attrgetter_constructor_callable() -> None:
+    with raises(
+        InstantiationException,
+        match=r"Target 'operator\.attrgetter'.*cannot be authorized",
+    ):
+        _resolve_target(
+            operator.attrgetter.__new__,
+            full_key="",
+            target_whitelist=("operator.attrgetter",),
+        )
+
+
+def test_attrgetter_constructor_alias_is_blocklisted() -> None:
+    with raises(
+        InstantiationException,
+        match=r"Target 'operator\.attrgetter'.*resolved from.*blocklisted",
+    ):
+        _instantiate2.instantiate({"_target_": "operator.attrgetter.__new__"})
+
+
+@mark.parametrize(
+    "target",
+    [
+        "operator.itemgetter.__new__",
+        "tests.instantiate.test_instantiate.operator_itemgetter.__new__",
+    ],
+)
+def test_target_whitelist_cannot_authorize_itemgetter_constructor(
+    target: str,
+) -> None:
+    with raises(
+        InstantiationException,
+        match=r"Target 'operator\.itemgetter'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate({"_target_": target}, _target_whitelist_=target)
+
+
+def test_itemgetter_constructor_alias_is_blocklisted() -> None:
+    with raises(
+        InstantiationException,
+        match=r"Target 'operator\.itemgetter'.*resolved from.*blocklisted",
+    ):
+        _instantiate2.instantiate({"_target_": "operator.itemgetter.__new__"})
+
+
+@mark.parametrize(
+    ("target", "descriptor", "canonical_target"),
+    [
+        (
+            "operator.attrgetter.__call__",
+            operator.attrgetter.__call__,
+            "operator.attrgetter",
+        ),
+        (
+            "operator.attrgetter.__reduce__",
+            operator.attrgetter.__reduce__,
+            "operator.attrgetter",
+        ),
+        (
+            "operator.itemgetter.__call__",
+            operator.itemgetter.__call__,
+            "operator.itemgetter",
+        ),
+        (
+            "operator.itemgetter.__reduce__",
+            operator.itemgetter.__reduce__,
+            "operator.itemgetter",
+        ),
+        (
+            "operator.methodcaller.__call__",
+            operator.methodcaller.__call__,
+            "operator.methodcaller",
+        ),
+        (
+            "operator.methodcaller.__reduce__",
+            operator.methodcaller.__reduce__,
+            "operator.methodcaller",
+        ),
+    ],
+)
+def test_target_whitelist_cannot_authorize_operator_dispatch_descriptors(
+    target: str, descriptor: Any, canonical_target: str
+) -> None:
+    match = rf"Target '{canonical_target}'.*cannot be authorized"
+    with raises(InstantiationException, match=match):
+        _instantiate2.instantiate({"_target_": target}, _target_whitelist_=target)
+
+    with raises(InstantiationException, match=match):
+        _resolve_target(descriptor, full_key="", target_whitelist=(target,))
+
+
+@mark.parametrize(
+    ("target", "canonical_target"),
+    [
+        ("operator.attrgetter.__call__", "operator.attrgetter"),
+        ("operator.itemgetter.__call__", "operator.itemgetter"),
+        ("operator.methodcaller.__call__", "operator.methodcaller"),
+    ],
+)
+def test_operator_dispatch_descriptors_are_blocklisted(
+    target: str, canonical_target: str
+) -> None:
+    with raises(
+        InstantiationException,
+        match=rf"Target '{canonical_target}'.*resolved from.*blocklisted",
+    ):
+        _instantiate2.instantiate({"_target_": target})
+
+
+def test_legacy_operator_error_does_not_recommend_target_whitelist() -> None:
+    with raises(InstantiationException) as exc_info:
+        _instantiate2.instantiate({"_target_": "operator.methodcaller"})
+
+    message = str(exc_info.value)
+    assert "_target_whitelist_" not in message
+    assert "UNSAFE_ALLOW_ALL_TARGETS" in message
+    assert "Set '_target_' to the intended callable instead" in message
+
+
+@mark.parametrize(
+    ("target", "receiver", "marker_owner", "target_whitelist"),
+    [
+        (
+            "builtins.object.__getattribute__",
+            {"_target_": "tests.instantiate.test_instantiate.GetattrDescriptorProbe"},
+            GetattrDescriptorProbe,
+            [
+                "builtins.object.__getattribute__",
+                "tests.instantiate.test_instantiate.GetattrDescriptorProbe",
+            ],
+        ),
+        (
+            "tests.instantiate.test_instantiate.object_getattribute",
+            {"_target_": "tests.instantiate.test_instantiate.GetattrDescriptorProbe"},
+            GetattrDescriptorProbe,
+            [
+                "tests.instantiate.test_instantiate.object_getattribute",
+                "tests.instantiate.test_instantiate.GetattrDescriptorProbe",
+            ],
+        ),
+        (
+            "builtins.type.__getattribute__",
+            {
+                "_target_": "hydra.utils.get_class",
+                "path": "tests.instantiate.test_instantiate.GetattributeTypeProbe",
+            },
+            GetattributeMeta,
+            [
+                "builtins.type.__getattribute__",
+                "hydra.utils.get_class",
+                "tests.instantiate.test_instantiate.GetattributeTypeProbe",
+            ],
+        ),
+        (
+            "tests.instantiate.test_instantiate.type_getattribute",
+            {
+                "_target_": "hydra.utils.get_class",
+                "path": "tests.instantiate.test_instantiate.GetattributeTypeProbe",
+            },
+            GetattributeMeta,
+            [
+                "tests.instantiate.test_instantiate.type_getattribute",
+                "hydra.utils.get_class",
+                "tests.instantiate.test_instantiate.GetattributeTypeProbe",
+            ],
+        ),
+    ],
+)
+def test_target_whitelist_rejects_getattribute_before_descriptor_access(
+    target: str,
+    receiver: Dict[str, Any],
+    marker_owner: Any,
+    target_whitelist: List[str],
+) -> None:
+    marker_owner.descriptor_accessed = False
+    cfg = {"_target_": target, "_args_": [receiver, "payload"]}
+
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.(?:object|type)\.__getattribute__'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_=target_whitelist)
+
+    assert not marker_owner.descriptor_accessed
+
+
+def test_target_whitelist_rejects_getattr_before_descriptor_access() -> None:
+    GetattrDescriptorProbe.descriptor_accessed = False
+    probe_target = "tests.instantiate.test_instantiate.GetattrDescriptorProbe"
+    cfg = {
+        "_target_": "builtins.getattr",
+        "_args_": [
+            {"_target_": probe_target},
+            "payload",
+        ],
+    }
+
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.getattr'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate(
+            cfg,
+            _target_whitelist_=[
+                "builtins.getattr",
+                probe_target,
+            ],
+        )
+
+    assert not GetattrDescriptorProbe.descriptor_accessed
+
+
+@mark.parametrize(
+    ("target", "canonical_target", "args", "marker"),
+    [
+        ("builtins.hasattr", "builtins.hasattr", ["payload"], "descriptor_accessed"),
+        (
+            "tests.instantiate.test_instantiate.builtin_hasattr",
+            "builtins.hasattr",
+            ["payload"],
+            "descriptor_accessed",
+        ),
+        ("builtins.setattr", "builtins.setattr", ["payload", 20], "descriptor_set"),
+        (
+            "tests.instantiate.test_instantiate.builtin_setattr",
+            "builtins.setattr",
+            ["payload", 20],
+            "descriptor_set",
+        ),
+        ("builtins.delattr", "builtins.delattr", ["payload"], "descriptor_deleted"),
+        (
+            "tests.instantiate.test_instantiate.builtin_delattr",
+            "builtins.delattr",
+            ["payload"],
+            "descriptor_deleted",
+        ),
+    ],
+)
+def test_target_whitelist_rejects_attribute_dispatch_before_descriptor_access(
+    target: str, canonical_target: str, args: List[Any], marker: str
+) -> None:
+    probe_target = "tests.instantiate.test_instantiate.GetattrDescriptorProbe"
+    setattr(GetattrDescriptorProbe, marker, False)
+    cfg = {
+        "_target_": target,
+        "_args_": [{"_target_": probe_target}, *args],
+    }
+
+    with raises(
+        InstantiationException,
+        match=rf"Target '{re.escape(canonical_target)}'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate(
+            cfg,
+            _target_whitelist_=[target, probe_target],
+        )
+
+    assert not getattr(GetattrDescriptorProbe, marker)
+
+
+@mark.parametrize(
+    ("target", "args", "marker"),
+    [
+        ("operator.getitem", ["payload"], "item_accessed"),
+        ("_operator.getitem", ["payload"], "item_accessed"),
+        ("operator.setitem", ["payload", 20], "item_set"),
+        ("_operator.setitem", ["payload", 20], "item_set"),
+        ("operator.delitem", ["payload"], "item_deleted"),
+        ("_operator.delitem", ["payload"], "item_deleted"),
+        ("operator.contains", ["payload"], "membership_checked"),
+        ("_operator.contains", ["payload"], "membership_checked"),
+    ],
+)
+def test_target_whitelist_rejects_item_dispatch_before_receiver_access(
+    target: str, args: List[Any], marker: str
+) -> None:
+    probe_target = "tests.instantiate.test_instantiate.ItemOperationProbe"
+    setattr(ItemOperationProbe, marker, False)
+    cfg = {
+        "_target_": target,
+        "_args_": [{"_target_": probe_target}, *args],
+    }
+
+    with raises(
+        InstantiationException,
+        match=r"Target '_?operator\.(?:contains|delitem|getitem|setitem)'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate(
+            cfg,
+            _target_whitelist_=[target, probe_target],
+        )
+
+    assert not getattr(ItemOperationProbe, marker)
+
+
+def test_getattr_allows_non_callable_result_in_legacy_mode() -> None:
+    cfg = {
+        "_target_": "builtins.getattr",
+        "_args_": [
+            {"_target_": "types.SimpleNamespace", "value": 10},
+            "value",
+        ],
+    }
+
+    with warns(UserWarning, match="_target_whitelist_"):
+        assert _instantiate2.instantiate(cfg) == 10
+
+
+def test_getattr_callable_result_applies_legacy_blocklist() -> None:
+    cfg = {
+        "_target_": "builtins.getattr",
+        "_args_": [
+            {"_target_": "timeit.Timer", "stmt": "40 + 2"},
+            "timeit",
+        ],
+    }
+
+    with (
+        warns(UserWarning, match="_target_whitelist_"),
+        raises(
+            InstantiationException,
+            match=r"Target 'timeit\.Timer\.timeit'.*blocklisted",
+        ),
+    ):
+        _instantiate2.instantiate(cfg)
+
+
+def test_getattr_unwraps_partial_callable_result() -> None:
+    cfg = {
+        "_target_": "builtins.getattr",
+        "_args_": [partial(eval), "__call__"],
+    }
+
+    with (
+        warns(UserWarning, match="_target_whitelist_"),
+        raises(
+            InstantiationException,
+            match=r"Target 'builtins\.eval'.*blocklisted",
+        ),
+    ):
+        _instantiate2.instantiate(cfg)
+
+
+def test_target_whitelist_cannot_authorize_getattr_callable_result() -> None:
+    cfg = {
+        "_target_": "builtins.getattr",
+        "_args_": [
+            {"_target_": "timeit.Timer", "stmt": "40 + 2"},
+            "timeit",
+        ],
+    }
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.getattr'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate(
+            cfg,
+            _target_whitelist_=[
+                "builtins.getattr",
+                "timeit.Timer",
+                "timeit.Timer.timeit",
+            ],
+        )
+
+
+def test_getattr_map_dispatch_chain_is_rejected() -> None:
+    cfg = {
+        "_target_": "builtins.list",
+        "_args_": [
+            {
+                "_target_": "builtins.map",
+                "_args_": [
+                    {
+                        "_target_": "builtins.getattr",
+                        "_args_": [
+                            {"_target_": "timeit.Timer", "stmt": "40 + 2"},
+                            "timeit",
+                        ],
+                    },
+                    [1],
+                ],
+            }
+        ],
+    }
+
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.getattr'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate(
+            cfg,
+            _target_whitelist_=[
+                "builtins.getattr",
+                "builtins.list",
+                "builtins.map",
+                "timeit.Timer",
+            ],
+        )
+
+
+def test_getattr_cannot_be_partial_with_target_whitelist() -> None:
+    cfg = {"_target_": "builtins.getattr", "_partial_": True}
+
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.getattr'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_="builtins.getattr")
+
+
+def test_unsafe_allow_all_permits_partial_getattr() -> None:
+    cfg = {"_target_": "builtins.getattr", "_partial_": True}
+
+    factory = _instantiate2.instantiate(
+        cfg, _target_whitelist_=UNSAFE_ALLOW_ALL_TARGETS
+    )
+    assert factory(str, "upper") is str.upper
+
+
+@mark.parametrize(
+    ("target", "target_whitelist"),
+    [
+        ("functools.partial", "functools.partial"),
+        ("functools.partial", "functools.*"),
+        (
+            "tests.instantiate.test_instantiate.partial",
+            "tests.instantiate.test_instantiate.partial",
+        ),
+    ],
+)
+def test_target_whitelist_authorizes_functools_partial_and_effective_callable(
+    target: str, target_whitelist: str
+) -> None:
+    cfg = {"_target_": target, "_args_": [pow], "exp": 2}
+
+    with warns(UserWarning, match=r"Using '_target_: functools\.partial'"):
+        factory = _instantiate2.instantiate(
+            cfg,
+            _target_whitelist_=[target_whitelist, "builtins.pow"],
+        )
+
+    assert factory(3) == 9
+
+
+def test_target_whitelist_checks_functools_partial_effective_callable() -> None:
+    cfg = {"_target_": "functools.partial", "_args_": [pow], "exp": 2}
+
+    with (
+        warns(UserWarning, match=r"Using '_target_: functools\.partial'"),
+        raises(
+            InstantiationException,
+            match=r"Target 'builtins\.pow'.*not in the instantiate target whitelist",
+        ),
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_="functools.partial")
+
+
+@mark.parametrize(
+    ("target", "target_whitelist"),
+    [
+        ("functools.partial.__new__", "functools.partial.__new__"),
+        ("functools.partial.__new__", "functools.*"),
+        (
+            "tests.instantiate.test_instantiate.partial.__new__",
+            "tests.instantiate.test_instantiate.partial.__new__",
+        ),
+    ],
+)
+def test_target_whitelist_authorizes_functools_partial_constructor(
+    target: str, target_whitelist: str
+) -> None:
+    cfg = {"_target_": target, "_args_": [partial, pow], "exp": 2}
+
+    with warns(UserWarning, match=r"Using '_target_: functools\.partial'"):
+        factory = _instantiate2.instantiate(
+            cfg,
+            _target_whitelist_=[target_whitelist, "builtins.pow"],
+        )
+
+    assert factory(3) == 9
+
+
+@mark.parametrize(
+    "target_whitelist", [None, ["functools.partial.__new__", "builtins.len"]]
+)
+def test_functools_partial_constructor_rejects_subclass_with_spoofed_func(
+    target_whitelist: Any,
+) -> None:
+    spoofed_partial = type(
+        "SpoofedPartial",
+        (partial,),
+        {"func": property(lambda _: len)},
+    )
+    cfg = {
+        "_target_": "functools.partial.__new__",
+        "_args_": [spoofed_partial, eval],
+    }
+
+    with (
+        warns(UserWarning),
+        raises(InstantiationException, match="cannot construct partial subclasses"),
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_=target_whitelist)
+
+
+def test_unsafe_allow_all_permits_functools_partial_subclass() -> None:
+    spoofed_partial = type(
+        "SpoofedPartial",
+        (partial,),
+        {"func": property(lambda _: len)},
+    )
+    cfg = {
+        "_target_": "functools.partial.__new__",
+        "_args_": [spoofed_partial, eval],
+    }
+
+    with warns(UserWarning, match=r"Using '_target_: functools\.partial'"):
+        factory = _instantiate2.instantiate(
+            cfg, _target_whitelist_=UNSAFE_ALLOW_ALL_TARGETS
+        )
+
+    assert factory("1 + 2") == 3
+
+
+def test_direct_functools_partial_applies_legacy_blocklist_to_callable() -> None:
+    cfg = {"_target_": "functools.partial", "_args_": [eval]}
+
+    with (
+        warns(UserWarning),
+        raises(
+            InstantiationException,
+            match=r"Target 'builtins\.eval'.*blocklisted",
+        ),
+    ):
+        _instantiate2.instantiate(cfg)
+
+
+def test_unsafe_allow_all_permits_blocklisted_functools_partial_callable() -> None:
+    cfg = {"_target_": "functools.partial", "_args_": [eval]}
+
+    with warns(UserWarning, match=r"Using '_target_: functools\.partial'"):
+        factory = _instantiate2.instantiate(
+            cfg, _target_whitelist_=UNSAFE_ALLOW_ALL_TARGETS
+        )
+
+    assert factory("1 + 2") == 3
+
+
+def test_direct_functools_partial_cannot_be_deferred_with_target_whitelist() -> None:
+    cfg = {"_target_": "functools.partial", "_partial_": True}
+
+    with (
+        warns(UserWarning, match=r"Using '_target_: functools\.partial'"),
+        raises(
+            InstantiationException,
+            match=r"cannot use '_partial_: true'",
+        ),
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_="functools.partial")
+
+
+def test_native_partial_remains_whitelistable() -> None:
+    cfg = {
+        "_target_": "tests.instantiate.module_function",
+        "_partial_": True,
+        "x": 10,
+    }
+
+    factory = _instantiate2.instantiate(
+        cfg, _target_whitelist_="tests.instantiate.module_function"
+    )
+
+    assert factory() == 10
+
+
+@mark.parametrize(
+    ("target", "target_whitelist"),
+    [
+        ("hydra.utils.instantiate", "hydra.utils.instantiate"),
+        ("hydra.utils.call", "hydra.utils.*"),
+        (
+            "hydra._internal.instantiate._instantiate2.instantiate",
+            "hydra._internal.instantiate._instantiate2.instantiate",
+        ),
+    ],
+)
+def test_target_whitelist_cannot_authorize_instantiate_reentry(
+    target: str, target_whitelist: str
+) -> None:
+    cfg = {"_target_": target, "_recursive_": False, "config": {}}
+
+    with raises(
+        InstantiationException,
+        match=r"reentrant instantiate calls do not safely inherit",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_=target_whitelist)
+
+
+@mark.parametrize(
+    ("target", "path", "expected"),
+    [
+        (
+            "hydra._internal.utils._locate",
+            "tests.instantiate.module_function",
+            module_function,
+        ),
+        ("hydra.utils.get_class", "tests.instantiate.AClass", AClass),
+        (
+            "hydra.utils.get_method",
+            "tests.instantiate.module_function",
+            module_function,
+        ),
+        (
+            "hydra.utils.get_static_method",
+            "tests.instantiate.module_function",
+            module_function,
+        ),
+        (
+            "hydra.utils.get_object",
+            "tests.instantiate.module_function",
+            module_function,
+        ),
+    ],
+)
+def test_discovery_targets_require_selected_path_authorization(
+    target: str, path: str, expected: Any
+) -> None:
+    cfg = {"_target_": target, "path": path}
+
+    with raises(
+        InstantiationException,
+        match=rf"Target '{re.escape(path)}' is not in the instantiate target whitelist",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_=target)
+
+    assert _instantiate2.instantiate(cfg, _target_whitelist_=[target, path]) is expected
+
+
+def test_internal_locate_requires_selected_path_authorization() -> None:
+    cfg = {
+        "_target_": "hydra._internal.utils._locate",
+        "path": "tests.instantiate.module_function",
+    }
+
+    with raises(
+        InstantiationException,
+        match="Target 'tests.instantiate.module_function' is not in the instantiate target whitelist",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_="hydra.*")
+
+
+def test_discovery_target_applies_legacy_blocklist_to_selected_path() -> None:
+    cfg = {"_target_": "hydra.utils.get_method", "path": "builtins.eval"}
+
+    with (
+        warns(UserWarning, match="_target_whitelist_"),
+        raises(
+            InstantiationException,
+            match="Target 'builtins.eval' is blocklisted",
+        ),
+    ):
+        _instantiate2.instantiate(cfg)
+
+
+@mark.parametrize(
+    "target",
+    [
+        "hydra._internal.utils._locate",
+        "hydra.utils.get_class",
+        "hydra.utils.get_method",
+        "hydra.utils.get_static_method",
+        "hydra.utils.get_object",
+    ],
+)
+def test_discovery_target_cannot_be_partial_with_target_whitelist(target: str) -> None:
+    cfg = {"_target_": target, "_partial_": True}
+
+    with raises(
+        InstantiationException,
+        match=r"cannot use '_partial_: true'",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_=target)
+
+
+def test_partial_discovery_target_applies_legacy_blocklist() -> None:
+    cfg = {
+        "_target_": "hydra.utils.get_method",
+        "_partial_": True,
+        "path": "logging.os.system",
+    }
+
+    with (
+        warns(UserWarning, match="_target_whitelist_"),
+        raises(
+            InstantiationException,
+            match=r"Target 'os\.system'.*blocklisted",
+        ),
+    ):
+        _instantiate2.instantiate(cfg)
+
+
+def test_unsafe_allow_all_permits_partial_discovery_target() -> None:
+    cfg = {"_target_": "hydra.utils.get_method", "_partial_": True}
+
+    factory = _instantiate2.instantiate(
+        cfg, _target_whitelist_=UNSAFE_ALLOW_ALL_TARGETS
+    )
+
+    assert factory("builtins.str") is str
 
 
 def test_target_whitelist_unsafe_allows_all_targets(instantiate_func: Any) -> None:
@@ -3743,7 +4823,7 @@ def test_whitelist_blocks_module_attribute_aliases() -> None:
     cfg = OmegaConf.create({"_target_": "logging.os.system", "_args_": ["true"]})
     with raises(
         InstantiationException,
-        match="not in the instantiate target whitelist",
+        match="cannot be authorized by the",
     ):
         _instantiate2.instantiate(cfg, _target_whitelist_="logging.*")
 
@@ -3767,11 +4847,17 @@ def test_whitelist_allows_os_callable_objects(target: Callable[..., Any]) -> Non
     assert _resolve_target(target, "", ("os.*",)) is target
 
 
-@mark.parametrize("target", ["posix.system", "ntpath.join"])
-def test_whitelist_does_not_alias_literal_target_strings(target: str) -> None:
-    with raises(
-        InstantiationException, match="not in the instantiate target whitelist"
-    ):
+@mark.parametrize(
+    ("target", "message"),
+    [
+        ("posix.system", "cannot be authorized by the"),
+        ("ntpath.join", "not in the instantiate target whitelist"),
+    ],
+)
+def test_whitelist_does_not_alias_literal_target_strings(
+    target: str, message: str
+) -> None:
+    with raises(InstantiationException, match=message):
         _resolve_target(target, "", ("os.*",))
 
 
@@ -3794,6 +4880,319 @@ def test_whitelist_wildcard_still_blocks_alias_after_exact_reexport_rule() -> No
     cfg = OmegaConf.create({"_target_": "logging.os.system", "_args_": ["true"]})
     with raises(
         InstantiationException,
-        match="not in the instantiate target whitelist",
+        match="cannot be authorized by the",
     ):
         _instantiate2.instantiate(cfg, _target_whitelist_="logging.*")
+
+
+@mark.parametrize(
+    "target",
+    [
+        "pickle.loads",
+        "pickle.load",
+        "pickle.Unpickler",
+        "_pickle.loads",  # canonical C spelling must be blocked too
+        "_pickle.load",
+        "marshal.loads",
+        "marshal.load",
+        "shelve.open",
+        "trace.CoverageResults",
+        "tracemalloc.Snapshot.load",
+        "dill.load",
+        "dill.loads",
+        "cloudpickle.load",
+        "cloudpickle.loads",
+    ],
+)
+def test_deserialization_sinks_are_blocklisted(target: str) -> None:
+    # Direct-instantiate unpickle sinks are refused on the legacy path. This
+    # removes the trivial inline RCE vector; the target whitelist remains the
+    # boundary, and users who genuinely need to deserialize wrap it in their own
+    # callable.
+    cfg = OmegaConf.create({"foo": {"_target_": target}})
+    with raises(InstantiationException, match="blocklisted"):
+        _instantiate2.instantiate(cfg)
+
+
+def test_pickle_base64_chain_is_blocklisted() -> None:
+    # The reporter's inline vector: pickle.loads(base64.b64decode("...")). The
+    # outer pickle.loads target is refused before the chain runs.
+    cfg = OmegaConf.create(
+        {
+            "_target_": "pickle.loads",
+            "_args_": [{"_target_": "base64.b64decode", "_args_": ["gA=="]}],
+        }
+    )
+    with raises(InstantiationException, match="blocklisted"):
+        _instantiate2.instantiate(cfg)
+
+
+@mark.parametrize(
+    "target",
+    [
+        "timeit.timeit",
+        "timeit.repeat",
+        "timeit.main",
+        "timeit.Timer.timeit",
+        "timeit.Timer.repeat",
+        "timeit.Timer.autorange",
+        "cProfile.run",
+        "cProfile.runctx",
+        "cProfile.Profile.run",
+        "cProfile.Profile.runctx",
+        "profile.run",
+        "profile.runctx",
+        "profile.Profile.run",
+        "profile.Profile.runctx",
+        "bdb.Bdb.run",
+        "bdb.Bdb.runeval",
+        "bdb.Bdb.runctx",
+        "pdb.run",
+        "pdb.runeval",
+        "pdb.Pdb.run",
+        "pdb.Pdb.runeval",
+        "pdb.Pdb.runctx",
+        "trace.Trace.run",
+        "trace.Trace.runctx",
+        "code.interact",
+        "code.InteractiveInterpreter.runsource",
+        "code.InteractiveInterpreter.runcode",
+        "code.InteractiveConsole.push",
+        "typing.ForwardRef._evaluate",
+        "typing._eval_type",
+        "typing.evaluate_forward_ref",
+        "typing.get_type_hints",
+        "annotationlib.ForwardRef._evaluate",
+        "annotationlib.ForwardRef.evaluate",
+        "annotationlib.get_annotations",
+        "optparse.Values.read_file",
+    ],
+)
+def test_exec_wrapper_targets_are_blocklisted(target: str) -> None:
+    # Standard-library functions that exec/eval a user-supplied string. They have
+    # no legitimate instantiate() use, so they are blocked directly (this is what
+    # closed the reporter's timeit.timeit vector). The whitelist stays the boundary.
+    cfg = OmegaConf.create({"foo": {"_target_": target}})
+    with raises(InstantiationException, match="blocklisted"):
+        _instantiate2.instantiate(cfg)
+
+
+@mark.parametrize(
+    "cfg",
+    [
+        {
+            "_target_": "bdb.Bdb.run",
+            "_args_": [
+                {"_target_": "bdb.Bdb"},
+                "raise RuntimeError('must not execute')",
+            ],
+        },
+        {
+            "_target_": "timeit.Timer.timeit",
+            "_args_": [
+                {
+                    "_target_": "timeit.Timer",
+                    "stmt": "raise RuntimeError('must not execute')",
+                },
+                1,
+            ],
+        },
+        {
+            "_target_": "doctest.debug_script",
+            "_args_": ["raise RuntimeError('must not execute')"],
+        },
+        {
+            "_target_": "typing.ForwardRef._evaluate",
+            "_args_": [
+                {
+                    "_target_": "typing.ForwardRef",
+                    "_args_": [
+                        "(_ for _ in ()).throw(RuntimeError('must not execute'))"
+                    ],
+                },
+                {},
+                {},
+            ],
+            "recursive_guard": {"_target_": "builtins.set"},
+        },
+        {
+            "_target_": "typing.get_type_hints",
+            "_args_": [
+                {
+                    "_target_": "builtins.type",
+                    "_args_": [
+                        "Probe",
+                        {"_target_": "builtins.tuple"},
+                        {
+                            "__annotations__": {
+                                "payload": "(_ for _ in ()).throw(RuntimeError('must not execute'))"
+                            }
+                        },
+                    ],
+                    "_convert_": "all",
+                }
+            ],
+        },
+    ],
+)
+def test_exec_wrapper_chains_are_blocklisted(cfg: Any) -> None:
+    with raises(InstantiationException, match="blocklisted"):
+        _instantiate2.instantiate(cfg)
+
+
+@mark.parametrize(
+    "target",
+    [
+        # pure-Python fallbacks — must not slip past the pickle block
+        "pickle._load",
+        "pickle._loads",
+        "pickle._Unpickler",
+        # exec-string siblings of cProfile.run / profile.run
+        "cProfile.runctx",
+        "profile.runctx",
+    ],
+)
+def test_blocklist_covers_alternate_sink_spellings(target: str) -> None:
+    cfg = OmegaConf.create({"foo": {"_target_": target}})
+    with raises(InstantiationException, match="blocklisted"):
+        _instantiate2.instantiate(cfg)
+
+
+@mark.parametrize(
+    "target",
+    [
+        "logging.config.dictConfig",
+        "logging.config.fileConfig",
+        "logging.config.BaseConfigurator.configure_custom",
+        "logging.config.DictConfigurator.configure",
+        "logging.config.DictConfigurator.configure_handler",
+        "logging.config.DictConfigurator.configure_formatter",
+        "logging.config.DictConfigurator.configure_filter",
+    ],
+)
+def test_logging_config_family_is_blocklisted(target: str) -> None:
+    # The whole logging.config namespace resolves/calls config-named factories
+    # (arbitrary code) on the legacy path. Covered by one prefix rather than
+    # enumerating configurator methods. Permanent control is the whitelist
+    # (GHSA-c3wx); this is the stopgap for 1.3 and the 1.4 legacy path.
+    cfg = OmegaConf.create({"foo": {"_target_": target}})
+    with raises(InstantiationException, match="blocklisted"):
+        _instantiate2.instantiate(cfg)
+
+
+@mark.parametrize(
+    "target",
+    [
+        "doctest.run_docstring_examples",
+        "doctest.testmod",
+        "doctest.testfile",
+        "doctest.Example.__init__",
+        "doctest.DocTestRunner.run",
+        "doctest.DebugRunner.run",
+        "doctest.debug_script",
+    ],
+)
+def test_doctest_family_is_blocklisted(target: str) -> None:
+    # doctest executes example code from docstrings/files; the whole family is
+    # covered by one prefix (no legitimate instantiate() use).
+    cfg = OmegaConf.create({"foo": {"_target_": target}})
+    with raises(InstantiationException, match="blocklisted"):
+        _instantiate2.instantiate(cfg)
+
+
+@mark.parametrize(
+    "target",
+    [
+        "shelve.open",
+        "shelve.DbfilenameShelf",
+        "shelve.Shelf",
+        "trace.CoverageResults",
+        "trace.Trace.results",
+        "trace.Trace.run",
+    ],
+)
+def test_shelve_and_trace_families_are_blocklisted(target: str) -> None:
+    # shelve shelf classes unpickle on access; trace delegates to CoverageResults
+    # which unpickles. Whole families covered by prefixes rather than one entry.
+    cfg = OmegaConf.create({"foo": {"_target_": target}})
+    with raises(InstantiationException, match="blocklisted"):
+        _instantiate2.instantiate(cfg)
+
+
+@mark.parametrize(
+    "target",
+    ["pydoc.importfile", "pydoc.safeimport", "pydoc.render_doc"],
+)
+def test_pydoc_family_is_blocklisted(target: str) -> None:
+    # pydoc imports/executes modules and files; covered by a prefix.
+    cfg = OmegaConf.create({"foo": {"_target_": target}})
+    with raises(InstantiationException, match="blocklisted"):
+        _instantiate2.instantiate(cfg)
+
+
+@mark.parametrize(
+    "cfg",
+    [
+        {
+            "_target_": "doctest.Example",
+            "source": "pass\n",
+            "want": "",
+        },
+        {
+            "_target_": "doctest.DocTest",
+            "_args_": [[], {}, "probe", "probe.py", 0, ""],
+            "_convert_": "all",
+        },
+        {"_target_": "doctest.DocTestParser"},
+        {"_target_": "pydoc.HTMLDoc"},
+        {"_target_": "pydoc.TextDoc"},
+        {"_target_": "trace.Trace"},
+    ],
+)
+def test_blocklist_prefix_exceptions_are_allowed(cfg: Dict[str, Any]) -> None:
+    with warns(UserWarning, match="with no\n_target_whitelist_"):
+        result = _instantiate2.instantiate(cfg)
+    assert result is not None
+
+    target = cfg["_target_"]
+    assert _instantiate2.instantiate(cfg, _target_whitelist_=target) is not None
+
+
+def test_exact_blocklist_takes_precedence_over_prefix_exception(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(
+        _instantiate2,
+        "DEFAULT_BLOCKLISTED_MODULES",
+        {*_instantiate2.DEFAULT_BLOCKLISTED_MODULES, "trace.CoverageResults"},
+    )
+    monkeypatch.setattr(
+        _instantiate2,
+        "UNCONTROLLED_EXECUTION_TARGET_PREFIX_EXCEPTIONS",
+        {
+            *_instantiate2.UNCONTROLLED_EXECUTION_TARGET_PREFIX_EXCEPTIONS,
+            "trace.CoverageResults",
+        },
+    )
+    assert _instantiate2._is_blocklisted_target("trace.CoverageResults")
+
+
+@mark.parametrize(
+    "target",
+    [
+        "pdb.run",
+        "pdb.runeval",
+        "pdb.Pdb._getval",
+        "pdb.Pdb._getval_except",
+        "pdb.Pdb.default",
+        "pdb.Pdb.run",
+        "bdb.Bdb.run",
+        "bdb.Bdb.runeval",
+        "bdb.Bdb.runctx",
+    ],
+)
+def test_debugger_families_are_blocklisted(target: str) -> None:
+    # pdb/bdb evaluate/execute user strings; whole families covered by prefix.
+    cfg = OmegaConf.create({"foo": {"_target_": target}})
+    with raises(InstantiationException, match="blocklisted"):
+        _instantiate2.instantiate(cfg)

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -462,6 +462,7 @@ obj_all = instantiate(cfg_all, _target_whitelist_="__main__.*")
 ```
 
 ### Partial Instantiation
+
 Sometimes you may not set all parameters needed to instantiate an object from the configuration, in this case you can set
 `_partial_` to be `True` to get a `functools.partial` wrapped object or method, then complete initializing the object in
 the application code. Here is an example:
@@ -557,6 +558,52 @@ assert bar1.foo is bar2.foo  # the `Foo` instance is re-used here
 This does not apply if `_partial_=False`,
 in which case a new `Foo` instance would be created with each call to `instantiate`.
 
+<details>
+<summary>Security considerations</summary>
+
+Hydra distinguishes between two denied-target classes. Generally problematic
+targets are blocked in legacy mode but trusted Python code can authorize them
+with `_target_whitelist_`. Targets that let config data control executable
+behavior, unsafe loading, imports, or generic dispatch cannot be authorized by
+a normal target whitelist. Use a narrow trusted wrapper instead. The explicit
+`UNSAFE_ALLOW_ALL_TARGETS` escape hatch disables both protections.
+
+Use the native `_partial_: true` option instead of configuring
+`_target_: functools.partial`. Direct `functools.partial` targets and equivalent
+constructor spellings such as `functools.partial.__new__` are deprecated. When
+used with `_target_whitelist_`, both the partial constructor and its effective
+callable must be authorized. Direct partial targets cannot themselves use
+`_partial_: true` with a real target whitelist because validation would be
+deferred. Equivalent constructor spellings also cannot construct partial
+subclasses while safety checks are active because subclass overrides can hide
+their invocation behavior.
+
+If a config targets `hydra.utils.get_class`, `get_method`,
+`get_static_method`, or `get_object`, whitelist both the discovery helper and
+the dotpath in its `path` argument. Hydra applies the same target policy to the
+selected path and to the canonical identity of a callable result. Discovery
+helpers cannot use `_partial_: true` with a real target whitelist because the
+path could be supplied after authorization has finished. Hydra's `instantiate`
+and `call` functions cannot themselves be authorized as config targets; invoke
+them from trusted Python code.
+
+Hydra does not authorize `builtins.getattr`, `hasattr`, `setattr`, or `delattr`
+through a real target whitelist. Attribute operations can execute property or
+custom descriptor code before Hydra can inspect the operation. Access or mutate
+the intended attribute from trusted Python code instead. The equivalent
+`object.__getattribute__` and `type.__getattribute__` dispatch targets cannot be
+authorized either. These targets remain available on the legacy no-whitelist
+path; `getattr` returns non-callable values normally and checks callable results
+against the blocklist. The explicit `UNSAFE_ALLOW_ALL_TARGETS` escape hatch
+preserves unrestricted legacy behavior.
+
+Hydra also refuses to authorize generic `operator` dispatch and selection
+targets, including `call`, `attrgetter`, `methodcaller`, `getitem`, `itemgetter`,
+`setitem`, `delitem`, and `contains`, or their canonical `_operator` spellings.
+Set `_target_` to the intended callable instead. These generic operator targets
+are also blocklisted on the legacy no-whitelist path.
+
+</details>
 
 ### Instantiation of builtins
 

--- a/website/docs/upgrades/1.3_to_1.4/instantiate_target_whitelist.md
+++ b/website/docs/upgrades/1.3_to_1.4/instantiate_target_whitelist.md
@@ -88,7 +88,103 @@ as `my_app.*` allows any importable target under that Python namespace, includin
 modules contributed by other installed distributions. For shared namespaces,
 prefer exact target names or narrower prefixes.
 
+## Migrate direct `functools.partial` targets
+
+Do not use `functools.partial` as `_target_`. It accepts the effective callable
+as config data. Hydra checks the completed partial's effective callable against
+the active target policy, so a target whitelist must authorize both the direct
+`functools.partial` spelling and the effective callable. Equivalent constructor
+spellings such as `functools.partial.__new__` receive the same check.
+
+Use Hydra's native partial support instead. Replace:
+
+```yaml
+_target_: functools.partial
+_args_:
+  - _target_: hydra.utils.get_class
+    path: my_app.Optimizer
+lr: 0.01
+```
+
+with:
+
+```yaml
+_target_: my_app.Optimizer
+_partial_: true
+lr: 0.01
+```
+
+Direct `functools.partial` targets remain deprecated and will become an error in
+Hydra 1.5. They cannot use `_partial_: true` with a real target whitelist
+because construction—and therefore validation of the effective callable—would
+be deferred. The explicit `UNSAFE_ALLOW_ALL_TARGETS` escape hatch permits that
+deferred behavior outside the target whitelist's security guarantee.
+Equivalent constructor spellings cannot construct partial subclasses while
+safety checks are active because subclass overrides can hide their invocation
+behavior.
+
+## Replace generic operator dispatch
+
+Hydra blocklists generic `operator` dispatch and selection targets on the legacy
+path and refuses to authorize them through `_target_whitelist_`. This includes
+`call`, `attrgetter`, `methodcaller`, `getitem`, `itemgetter`, `setitem`,
+`delitem`, and `contains`, plus their canonical `_operator` spellings. These
+targets let config data select the effective callable, attribute, method, or
+item operation instead of naming it as `_target_`, which can extend a narrow
+whitelist entry into generic selection or dispatch authority. Set `_target_` to
+the intended callable, or call it from trusted Python code, instead.
+
+## Authorize config-selected callable results
+
+When `hydra.utils.get_class`, `get_method`, `get_static_method`, or
+`get_object` is itself an instantiate target, its `path` value selects another
+object. Authorize both the helper and the selected path from trusted code:
+
+```python
+obj = instantiate(
+    {
+        "_target_": "hydra.utils.get_method",
+        "path": "my_app.make_model",
+    },
+    _target_whitelist_=[
+        "hydra.utils.get_method",
+        "my_app.make_model",
+    ],
+)
+```
+
+Hydra applies the active blocklist or whitelist to the selected path and
+rechecks callable results by canonical identity. This prevents a trusted
+whitelist entry for the helper from authorizing an unrelated callable selected
+by config data.
+
+Hydra does not authorize `builtins.getattr`, `hasattr`, `setattr`, or `delattr`
+through a real target whitelist. Attribute operations can execute property or
+custom descriptor code before Hydra can inspect and authorize the operation.
+Access or mutate the intended attribute from trusted Python code instead. The
+equivalent `object.__getattribute__` and `type.__getattribute__` dispatch targets
+cannot be authorized either.
+
+Discovery helpers cannot use `_partial_: true` with a real target whitelist.
+The partial could receive its selected path after instantiate's authorization
+has finished. Resolve the value immediately, or expose a narrow trusted Python
+wrapper for the intended operation. The explicit `UNSAFE_ALLOW_ALL_TARGETS`
+escape hatch keeps discovery and attribute access unrestricted. On the legacy
+no-whitelist path, immediately selected callables are still checked against the
+blocklist and ordinary non-callable attribute values remain unchanged.
+
+Do not configure `hydra.utils.instantiate`, `hydra.utils.call`, or the internal
+`instantiate` function as `_target_`. Hydra refuses to authorize these aliases
+because a reentrant call cannot yet safely inherit the effective whitelist.
+Call `instantiate()` from trusted Python code instead.
+
 ## Legacy behavior
+
+The legacy blocklist has two policy levels. Generally problematic operations
+are blocked by default but can be explicitly authorized from trusted Python
+code. Targets that let config data control executable behavior, unsafe loading,
+imports, or generic dispatch are blocked in legacy mode and cannot be
+authorized by a normal target whitelist. Use a narrow trusted wrapper instead.
 
 To preserve legacy all-target behavior, use `UNSAFE_ALLOW_ALL_TARGETS`
 explicitly:


### PR DESCRIPTION
Harden Hydra's legacy instantiate path by blocking additional direct targets
that can deserialize attacker-controlled data, evaluate expressions, or execute
code through standard-library wrappers.

Separate denied targets into generally problematic operations that trusted
Python code may authorize with a target whitelist and config-controlled
execution, import, unsafe-loading, or generic-dispatch surfaces that a normal
target whitelist cannot authorize. Narrow trusted wrappers remain available;
`UNSAFE_ALLOW_ALL_TARGETS` is the explicit opt-out from all target checks.

Also harden target-whitelist authorization by using canonical resolved
identities; refusing generic selection, dispatch, unsafe attribute access, and
reentrant instantiate surfaces; and validating paths and callables selected by
Hydra discovery helpers and direct `functools.partial` targets. Reusable
whitelist context state is isolated across concurrent execution contexts.
Direct `functools.partial` targets remain compatible for 1.4 but are deprecated
in favor of Hydra's native `_partial_: true` support.

Add exploit-shaped and compatibility regression coverage, including descriptor
side effects, constructor aliases, deferred selection, partial subclasses,
descriptor aliases, and overlapping async contexts. Document migration to
explicit target whitelists and native partial support.

The legacy blocklist remains a best-effort defense-in-depth stopgap rather than
a complete security boundary.

Fixes #3411

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
