### PR TITLE
Backport instantiate target authorization hardening to 1.3

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -2,37 +2,34 @@
 
 import copy
 import functools
+import inspect
+import itertools
+import operator
 import os
+import types
 from enum import Enum
 from textwrap import dedent
-from typing import Any, Callable, Dict, List, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Sequence, Set, Tuple, Union
 
 from omegaconf import OmegaConf, SCMode
 from omegaconf._utils import is_structured_config
 
+from hydra._internal.deprecation_warning import deprecation_warning
 from hydra._internal.utils import _locate
 from hydra.errors import InstantiationException
 from hydra.types import ConvertMode, TargetConf
 
+# This blocklist is a best-effort, defense-in-depth stopgap. It is not a
+# complete security boundary because application callables can indirectly
+# dispatch operations that never appear as _target_ values.
+#
+# These operations are fully named by the target itself. Trusted users may
+# authorize them with HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE.
 DEFAULT_BLOCKLISTED_MODULES = {
-    "builtins.exec",
-    "builtins.eval",
-    "builtins.__import__",
-    "builtins.compile",
+    "_sitebuiltins.Quitter",
     "builtins.exit",
     "builtins.quit",
-    "ctypes.CDLL",
-    "ctypes.OleDLL",
-    "ctypes.PyDLL",
-    "ctypes.WinDLL",
-    "ctypes.cdll.LoadLibrary",
-    "ctypes.oledll.LoadLibrary",
-    "ctypes.pydll.LoadLibrary",
-    "ctypes.windll.LoadLibrary",
-    "importlib.import_module",
     "os.kill",
-    "os.system",
-    "os.popen",
     "os.putenv",
     "os.remove",
     "os.removedirs",
@@ -44,9 +41,6 @@ DEFAULT_BLOCKLISTED_MODULES = {
     "os.killpg",
     "os.rename",
     "os.renames",
-    "os.startfile",
-    "os.posix_spawn",
-    "os.posix_spawnp",
     "os.truncate",
     "os.replace",
     "os.unlink",
@@ -55,44 +49,237 @@ DEFAULT_BLOCKLISTED_MODULES = {
     "os.chmod",
     "os.chown",
     "os.chroot",
-    "os.fchdir",
     "os.lchflags",
     "os.lchmod",
     "os.lchown",
-    "os.getcwd",
     "os.chdir",
-    "pty.spawn",
-    "runpy.run_module",
-    "runpy.run_path",
     "shutil.rmtree",
     "shutil.move",
     "shutil.chown",
+}
+
+# These dispatchers execute caller-supplied callables and return their results
+# directly or through a container, iterator, or deferred result. That allows
+# selection, wrapping, and invocation to happen outside instantiate's immediate
+# callable-result authorization.
+CALLBACK_DISPATCH_TARGETS = {
+    "builtins.map",
+    "concurrent.futures._base.Executor.map",
+    "concurrent.futures._base.Executor.submit",
+    "concurrent.futures.process.ProcessPoolExecutor.map",
+    "concurrent.futures.process.ProcessPoolExecutor.submit",
+    "concurrent.futures.thread.ThreadPoolExecutor.submit",
+    "functools.reduce",
+    "itertools.accumulate",
+    "itertools.groupby",
+    "itertools.starmap",
+    "multiprocessing.pool.Pool._map_async",
+    "multiprocessing.pool.Pool.apply",
+    "multiprocessing.pool.Pool.apply_async",
+    "multiprocessing.pool.Pool.imap",
+    "multiprocessing.pool.Pool.imap_unordered",
+    "multiprocessing.pool.Pool.map",
+    "multiprocessing.pool.Pool.map_async",
+    "multiprocessing.pool.Pool.starmap",
+    "multiprocessing.pool.Pool.starmap_async",
+    "_functools.reduce",
+}
+
+_CALLABLE_DESCRIPTOR_BINDING_TARGETS: Dict[type, str] = {
+    types.ClassMethodDescriptorType: "types.ClassMethodDescriptorType.__get__",
+    types.FunctionType: "types.FunctionType.__get__",
+    types.MethodDescriptorType: "types.MethodDescriptorType.__get__",
+    types.WrapperDescriptorType: "types.WrapperDescriptorType.__get__",
+}
+
+# These helpers construct, bind, or relabel callable wrappers whose later
+# invocation can return an unauthorized callable outside instantiate's result
+# mediation.
+CALLABLE_WRAPPER_TARGETS = {
+    "builtins.classmethod",
+    "builtins.staticmethod",
+    "contextlib.AsyncContextDecorator.__call__",
+    "contextlib.ContextDecorator.__call__",
+    "functools.cache",
+    "functools.lru_cache",
+    "functools.partialmethod",
+    "functools.partialmethod.__get__",
+    "functools.singledispatch",
+    "functools.singledispatchmethod",
+    "functools.singledispatchmethod.__get__",
+    "functools.update_wrapper",
+    "functools.wraps",
+    "types.FunctionType",
+    "types.MethodType",
+    "unittest.mock.AsyncMock",
+    "unittest.mock.MagicMock",
+    "unittest.mock.Mock",
+    "unittest.mock.PropertyMock",
+    "unittest.mock.create_autospec",
+    "unittest.mock.mock_open",
+} | set(_CALLABLE_DESCRIPTOR_BINDING_TARGETS.values())
+
+_NON_CALLABLE_MOCK_TARGETS = {
+    "unittest.mock.NonCallableMagicMock",
+    "unittest.mock.NonCallableMock",
+}
+_NON_CALLABLE_MOCK_SAFE_PARAMETERS = {"name", "spec", "spec_set"}
+
+# These targets allow config data to select or supply executable behavior.
+# They cannot be authorized with HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE.
+UNCONTROLLED_EXECUTION_TARGETS = {
+    "_sitebuiltins._Helper",
+    "builtins.__build_class__",
+    "builtins.__import__",
+    "builtins.compile",
+    "builtins.eval",
+    "builtins.exec",
+    "builtins.help",
+    "builtins.type.__call__",
+    "builtins.type.__new__",
+    "operator.attrgetter",
+    "operator.call",
+    "operator.contains",
+    "operator.delitem",
+    "operator.getitem",
+    "operator.itemgetter",
+    "operator.methodcaller",
+    "operator.setitem",
+    "_operator.attrgetter",
+    "_operator.call",
+    "_operator.contains",
+    "_operator.delitem",
+    "_operator.getitem",
+    "_operator.itemgetter",
+    "_operator.methodcaller",
+    "_operator.setitem",
+    "ctypes.CDLL",
+    "ctypes.LibraryLoader.LoadLibrary",
+    "ctypes.OleDLL",
+    "ctypes.PyDLL",
+    "ctypes.WinDLL",
+    "ctypes.cdll.LoadLibrary",
+    "ctypes.oledll.LoadLibrary",
+    "ctypes.pydll.LoadLibrary",
+    "ctypes.windll.LoadLibrary",
+    "dataclasses.make_dataclass",
+    "importlib.import_module",
+    "importlib.machinery.ExtensionFileLoader.create_module",
+    "importlib.machinery.ExtensionFileLoader.exec_module",
+    "importlib.machinery.ExtensionFileLoader.load_module",
+    "importlib.machinery.SourceFileLoader.exec_module",
+    "importlib.machinery.SourceFileLoader.load_module",
+    "importlib.machinery.SourcelessFileLoader.exec_module",
+    "importlib.machinery.SourcelessFileLoader.load_module",
+    "_frozen_importlib_external.ExtensionFileLoader.create_module",
+    "_frozen_importlib_external.ExtensionFileLoader.exec_module",
+    "_frozen_importlib_external.FileLoader.load_module",
+    "_frozen_importlib_external._LoaderBasics.exec_module",
+    "os.popen",
+    "os.posix_spawn",
+    "os.posix_spawnp",
+    "os.startfile",
+    "os.system",
+    "pty.spawn",
+    "runpy.run_module",
+    "runpy.run_path",
     "subprocess.Popen",
-    "subprocess.run",
     "subprocess.call",
     "subprocess.check_call",
     "subprocess.check_output",
     "subprocess.getoutput",
     "subprocess.getstatusoutput",
-    "builtins.help",
-    "sys.modules.ipdb",
-    "sys.modules.joblib",
-    "sys.modules.resource",
-    "sys.modules.psutil",
-    "sys.modules.tkinter",
-}
+    "subprocess.run",
+    "pickle.load",
+    "pickle.loads",
+    "pickle.Unpickler",
+    "pickle._load",
+    "pickle._loads",
+    "pickle._Unpickler",
+    "_pickle.load",
+    "_pickle.loads",
+    "_pickle.Unpickler",
+    "marshal.load",
+    "marshal.loads",
+    "tracemalloc.Snapshot.load",
+    "dill.load",
+    "dill.loads",
+    "cloudpickle.load",
+    "cloudpickle.loads",
+    "timeit.timeit",
+    "timeit.repeat",
+    "timeit.main",
+    "timeit.Timer.timeit",
+    "timeit.Timer.repeat",
+    "timeit.Timer.autorange",
+    "cProfile.run",
+    "cProfile.runctx",
+    "cProfile.Profile.run",
+    "cProfile.Profile.runctx",
+    "profile.run",
+    "profile.runctx",
+    "profile.Profile.run",
+    "profile.Profile.runctx",
+    "code.interact",
+    "code.InteractiveInterpreter.runsource",
+    "code.InteractiveInterpreter.runcode",
+    "code.InteractiveConsole.push",
+    "typing.ForwardRef._evaluate",
+    "typing._eval_type",
+    "typing.evaluate_forward_ref",
+    "typing.get_type_hints",
+    "types.new_class",
+    "unittest.mock.patch",
+    "unittest.mock.patch.dict",
+    "unittest.mock.patch.multiple",
+    "unittest.mock.patch.object",
+    "annotationlib.ForwardRef._evaluate",
+    "annotationlib.ForwardRef.evaluate",
+    "annotationlib.get_annotations",
+    "optparse.Values.read_file",
+    "optparse.Values.read_module",
+} | CALLBACK_DISPATCH_TARGETS | CALLABLE_WRAPPER_TARGETS
 
-DEFAULT_BLOCKLISTED_MODULE_PREFIXES = (
+UNCONTROLLED_EXECUTION_TARGET_PREFIXES = (
     "os.exec",
     "os.spawn",
+    "logging.config.",
+    "doctest.",
+    "shelve.",
+    "trace.",
+    "pydoc.",
+    "pdb.",
+    "bdb.",
 )
+
+UNCONTROLLED_EXECUTION_TARGET_PREFIX_EXCEPTIONS = {
+    "doctest.DocTest",
+    "doctest.DocTestParser",
+    "doctest.Example",
+    "pydoc.HTMLDoc",
+    "pydoc.TextDoc",
+    "trace.Trace",
+}
+
+DISCOVERY_TARGETS = {
+    "hydra._internal.utils._locate",
+    "hydra.utils.get_class",
+    "hydra.utils.get_method",
+    "hydra.utils.get_static_method",
+    "hydra.utils.get_object",
+}
 
 
 def _get_os_alias_target(target: str) -> str:
-    for module in ("posix", "nt"):
+    for module, public_module in (
+        ("posix", "os"),
+        ("nt", "os"),
+        ("posixpath", "os.path"),
+        ("ntpath", "os.path"),
+    ):
         module_prefix = f"{module}."
         if target.startswith(module_prefix):
-            return f"os.{target[len(module_prefix):]}"
+            return f"{public_module}.{target[len(module_prefix):]}"
     return target
 
 
@@ -116,9 +303,310 @@ def _is_target(x: Any) -> bool:
 
 def _is_blocklisted_target(target: str) -> bool:
     canonical_target = _get_os_alias_target(target)
-    return (
+    if (
         canonical_target in DEFAULT_BLOCKLISTED_MODULES
-        or canonical_target.startswith(DEFAULT_BLOCKLISTED_MODULE_PREFIXES)
+        or canonical_target in UNCONTROLLED_EXECUTION_TARGETS
+    ):
+        return True
+    if canonical_target in UNCONTROLLED_EXECUTION_TARGET_PREFIX_EXCEPTIONS:
+        return False
+    return canonical_target.startswith(UNCONTROLLED_EXECUTION_TARGET_PREFIXES)
+
+
+def _is_uncontrolled_execution_target(target: str) -> bool:
+    canonical_target = _get_os_alias_target(target)
+    if canonical_target in UNCONTROLLED_EXECUTION_TARGETS:
+        return True
+    if canonical_target in UNCONTROLLED_EXECUTION_TARGET_PREFIX_EXCEPTIONS:
+        return False
+    return canonical_target.startswith(UNCONTROLLED_EXECUTION_TARGET_PREFIXES)
+
+
+def _get_target_name_for_check(target: Union[str, type, Callable[..., Any]]) -> str:
+    if isinstance(target, str):
+        return target
+    module = getattr(target, "__module__", None)
+    qualname = getattr(target, "__qualname__", None)
+    if module is not None and qualname is not None:
+        return f"{module}.{qualname}"
+    target_type = type(target)
+    return f"{target_type.__module__}.{target_type.__qualname__}"
+
+
+def _get_resolved_target_name_for_check(target: Callable[..., Any]) -> str:
+    """Return the security identity of a resolved callable."""
+    seen: Set[int] = set()
+    while id(target) not in seen:
+        seen.add(id(target))
+        if getattr(target, "__name__", None) == "__call__":
+            owner = getattr(target, "__self__", None)
+            if owner is not None and callable(owner):
+                target = owner
+                continue
+        if isinstance(target, functools.partial):
+            target = target.func
+            continue
+        break
+    descriptor_owner = getattr(target, "__objclass__", None)
+    if getattr(target, "__name__", None) == "__get__":
+        descriptor_binding_target = _CALLABLE_DESCRIPTOR_BINDING_TARGETS.get(
+            descriptor_owner
+        )
+        if descriptor_binding_target is not None:
+            return descriptor_binding_target
+    if descriptor_owner is operator.attrgetter:
+        return "operator.attrgetter"
+    if descriptor_owner is operator.itemgetter:
+        return "operator.itemgetter"
+    if descriptor_owner is operator.methodcaller:
+        return "operator.methodcaller"
+    if descriptor_owner is type and getattr(target, "__name__", None) == "__call__":
+        return "builtins.type.__call__"
+    if descriptor_owner is types.FunctionType:
+        return "types.FunctionType"
+    if descriptor_owner is types.MethodType:
+        return "types.MethodType"
+    if descriptor_owner is classmethod:
+        return "builtins.classmethod"
+    if descriptor_owner is staticmethod:
+        return "builtins.staticmethod"
+    if target is functools.partial.__new__:
+        return "functools.partial"
+    if target is type.__new__:
+        return "builtins.type.__new__"
+    if target is classmethod or target is classmethod.__new__:
+        return "builtins.classmethod"
+    if target is staticmethod or target is staticmethod.__new__:
+        return "builtins.staticmethod"
+    if target is types.FunctionType or target is types.FunctionType.__new__:
+        return "types.FunctionType"
+    if target is types.MethodType or target is types.MethodType.__new__:
+        return "types.MethodType"
+    if target is map.__new__:
+        return "builtins.map"
+    if target is itertools.accumulate.__new__:
+        return "itertools.accumulate"
+    if target is itertools.groupby.__new__:
+        return "itertools.groupby"
+    if target is itertools.starmap.__new__:
+        return "itertools.starmap"
+    if target is operator.attrgetter.__new__:
+        return "operator.attrgetter"
+    if target is operator.itemgetter.__new__:
+        return "operator.itemgetter"
+    if target is operator.methodcaller.__new__:
+        return "operator.methodcaller"
+    return _get_target_name_for_check(target)
+
+
+def _with_full_key(message: str, full_key: str) -> str:
+    return f"{message}\nfull_key: {full_key}" if full_key else message
+
+
+def _resolved_from_note(target_name: str, resolved_from: str) -> str:
+    return "" if resolved_from == target_name else f" (resolved from '{resolved_from}')"
+
+
+def _authorize_target_name(
+    target_name: str,
+    resolved_from: str,
+    full_key: str,
+    *,
+    resolved_from_is_alias: bool = False,
+) -> None:
+    canonical_target = _get_os_alias_target(target_name)
+    resolved_note = _resolved_from_note(canonical_target, resolved_from)
+    if _is_uncontrolled_execution_target(canonical_target):
+        msg = dedent(f"""\
+            Target '{canonical_target}'{resolved_note} is blocklisted because it allows
+            config data to control executable behavior or belongs to an
+            execution-capable target family. It cannot be authorized with
+            HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE.""")
+        raise InstantiationException(_with_full_key(msg, full_key))
+    if canonical_target not in DEFAULT_BLOCKLISTED_MODULES:
+        return
+
+    allowlist = os.environ.get("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "")
+    allowlist_entries = allowlist.split(":")
+    if (
+        target_name in allowlist_entries
+        or canonical_target in allowlist_entries
+        or (resolved_from_is_alias and resolved_from in allowlist_entries)
+    ):
+        return
+    msg = dedent(
+        f"""\
+        Target '{canonical_target}'{resolved_note} is blocklisted and cannot be instantiated from config
+        to prevent security vulnerabilities, set env var
+        HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE={canonical_target}:<other allowlisted targets> to bypass"""
+    )
+    raise InstantiationException(_with_full_key(msg, full_key))
+
+
+def _authorize_discovery_path(
+    target: Callable[..., Any],
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+    full_key: str,
+) -> Union[str, None]:
+    target_name = _get_resolved_target_name_for_check(target)
+    if target_name not in DISCOVERY_TARGETS:
+        return None
+    path = args[0] if args else kwargs.get("path")
+    if not isinstance(path, str):
+        return None
+    _authorize_target_name(path, path, full_key)
+    return path
+
+
+def _authorize_callable_result(
+    result: Callable[..., Any],
+    resolved_from: str,
+    full_key: str,
+    *,
+    resolved_from_is_alias: bool = False,
+) -> None:
+    resolved_name = _get_os_alias_target(_get_resolved_target_name_for_check(result))
+    _authorize_target_name(
+        resolved_name,
+        resolved_from,
+        full_key,
+        resolved_from_is_alias=resolved_from_is_alias,
+    )
+
+
+def _authorize_target_invocation(
+    target: Callable[..., Any],
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+    full_key: str,
+    *,
+    allow_incomplete_partial: bool = False,
+) -> None:
+    target_name = _get_resolved_target_name_for_check(target)
+    if target_name in _NON_CALLABLE_MOCK_TARGETS:
+        unsafe_parameters = sorted(
+            set(kwargs).difference(_NON_CALLABLE_MOCK_SAFE_PARAMETERS)
+        )
+        if len(args) > 1 or unsafe_parameters:
+            unsafe_details = list(unsafe_parameters)
+            if len(args) > 1:
+                unsafe_details.append(f"{len(args)} positional arguments")
+            joined = ", ".join(unsafe_details)
+            msg = dedent(f"""\
+                Target '{target_name}' cannot configure callable attributes,
+                children, or wrappers from config (unsafe parameters: {joined}).
+                Only one positional spec and the name, spec, and spec_set keyword
+                parameters are allowed. This restriction cannot be bypassed with
+                HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE.""")
+            raise InstantiationException(_with_full_key(msg, full_key))
+
+    if getattr(target, "__name__", None) in {"__call__", "__new__"}:
+        module = getattr(target, "__module__", None)
+        qualname = getattr(target, "__qualname__", "")
+        owner_qualname, separator, _ = qualname.rpartition(".")
+        if module is not None and separator and "<locals>" not in owner_qualname:
+            try:
+                owner = _locate(f"{module}.{owner_qualname}")
+            except Exception:
+                owner = None
+            if isinstance(owner, type) and issubclass(owner, type):
+                msg = dedent(f"""\
+                    Target '{target_name}' cannot be used for dynamic class construction
+                    from config. Metaclass constructor methods cannot be authorized with
+                    HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE.""")
+                raise InstantiationException(_with_full_key(msg, full_key))
+
+    if not isinstance(target, type) or not issubclass(target, type):
+        return
+    if allow_incomplete_partial and len(args) <= 1 and not kwargs:
+        return
+    if len(args) == 1 and not kwargs:
+        return
+    msg = dedent(f"""\
+        Target '{target_name}' cannot be used for dynamic class construction
+        from config. Only one-argument type(obj) introspection is allowed, and
+        this restriction cannot be bypassed with HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE.""")
+    raise InstantiationException(_with_full_key(msg, full_key))
+
+
+class _DeferredTarget(functools.partial):  # type: ignore[type-arg]
+    """Authorize callable results when a Hydra partial is invoked."""
+
+    _hydra_resolved_from: str
+    _hydra_full_key: str
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        effective_args = self.args + args
+        effective_kwargs = {**(self.keywords or {}), **kwargs}
+        _authorize_target_invocation(
+            self.func,
+            effective_args,
+            effective_kwargs,
+            self._hydra_full_key,
+        )
+        discovery_path = _authorize_discovery_path(
+            self.func,
+            effective_args,
+            effective_kwargs,
+            self._hydra_full_key,
+        )
+        result = super().__call__(*args, **kwargs)
+        return _mediate_target_result(
+            result,
+            discovery_path or self._hydra_resolved_from,
+            self._hydra_full_key,
+            resolved_from_is_alias=discovery_path is not None,
+        )
+
+
+def _mediate_target_result(
+    result: Any,
+    resolved_from: str,
+    full_key: str,
+    *,
+    resolved_from_is_alias: bool = False,
+) -> Any:
+    if isinstance(result, functools.partial) and type(result) is not _DeferredTarget:
+        if type(result) is not functools.partial:
+            msg = dedent("""\
+                Callable targets cannot return partial subclasses because overrides
+                can hide their invocation behavior. Return an exact functools.partial
+                or use Hydra's '_partial_: true' support instead.""")
+            raise InstantiationException(_with_full_key(msg, full_key))
+        deferred = _DeferredTarget(
+            result.func,
+            *result.args,
+            **(result.keywords or {}),
+        )
+        deferred.__dict__.update(result.__dict__)
+        deferred._hydra_resolved_from = resolved_from
+        deferred._hydra_full_key = full_key
+        result = deferred
+    if callable(result):
+        _authorize_callable_result(
+            result,
+            resolved_from,
+            full_key,
+            resolved_from_is_alias=resolved_from_is_alias,
+        )
+    return result
+
+
+def _warn_direct_functools_partial_target() -> None:
+    stacklevel = 1
+    frame = inspect.currentframe()
+    while frame is not None:
+        if frame.f_code.co_filename != __file__:
+            break
+        stacklevel += 1
+        frame = frame.f_back
+    deprecation_warning(
+        dedent("""\
+            Using '_target_: functools.partial' is deprecated. Set '_target_' to
+            the effective callable and use '_partial_: true' instead. Direct
+            functools.partial targets will become an error in Hydra 1.5."""),
+        stacklevel=stacklevel,
     )
 
 
@@ -166,29 +654,43 @@ def _call_target(
 
         raise InstantiationException(msg) from e
 
-    if _partial_:
-        try:
-            return functools.partial(_target_, *args, **kwargs)
-        except Exception as e:
+    resolved_target_name = _get_resolved_target_name_for_check(_target_)
+    _authorize_target_invocation(
+        _target_,
+        args,
+        kwargs,
+        full_key,
+        allow_incomplete_partial=_partial_,
+    )
+    discovery_path = _authorize_discovery_path(_target_, args, kwargs, full_key)
+
+    try:
+        if _partial_:
+            deferred = _DeferredTarget(_target_, *args, **kwargs)
+            deferred._hydra_resolved_from = discovery_path or resolved_target_name
+            deferred._hydra_full_key = full_key
+            return deferred
+        result = _target_(*args, **kwargs)
+    except Exception as e:
+        if _partial_:
             msg = (
                 f"Error in creating partial({_convert_target_to_string(_target_)}, ...) object:"
                 + f"\n{repr(e)}"
             )
-            if full_key:
-                msg += f"\nfull_key: {full_key}"
-            raise InstantiationException(msg) from e
-    else:
-        try:
-            return _target_(*args, **kwargs)
-        except Exception as e:
+        else:
             msg = f"Error in call to target '{_convert_target_to_string(_target_)}':\n{repr(e)}"
-            if full_key:
-                msg += f"\nfull_key: {full_key}"
-            raise InstantiationException(msg) from e
+        raise InstantiationException(_with_full_key(msg, full_key)) from e
+
+    return _mediate_target_result(
+        result,
+        discovery_path or resolved_target_name,
+        full_key,
+        resolved_from_is_alias=discovery_path is not None,
+    )
 
 
 def _convert_target_to_string(t: Any) -> Any:
-    if callable(t):
+    if callable(t) and hasattr(t, "__qualname__"):
         return f"{t.__module__}.{t.__qualname__}"
     else:
         return t
@@ -219,29 +721,38 @@ def _resolve_target(
     target: Union[str, type, Callable[..., Any]], full_key: str
 ) -> Union[type, Callable[..., Any]]:
     """Resolve target string, type or callable into type or callable."""
-    if isinstance(target, str):
-        if _is_blocklisted_target(target):
-            allowlist = os.environ.get("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "")
-            allowlist_entries = allowlist.split(":")
-            canonical_target = _get_os_alias_target(target)
-            if target not in allowlist_entries and canonical_target not in allowlist_entries:
-                msg = dedent(
-                    f"""\
-                    Target '{target}' is blocklisted and cannot be instantiated from config
-                    to prevent security vulnerabilities, set env var
-                    HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE={target}:<other allowlisted targets> to bypass"""
-                )
+    if isinstance(target, str) or callable(target):
+        target_name = (
+            target
+            if isinstance(target, str)
+            else _get_os_alias_target(_get_resolved_target_name_for_check(target))
+        )
+        _authorize_target_name(target_name, target_name, full_key)
+
+        resolved_name = target_name
+        if isinstance(target, str):
+            resolved_from = target
+            try:
+                target = _locate(target)
+            except Exception as e:
+                msg = f"Error locating target '{target}', set env var HYDRA_FULL_ERROR=1 to see chained exception."
                 if full_key:
                     msg += f"\nfull_key: {full_key}"
-                raise InstantiationException(msg)
+                raise InstantiationException(msg) from e
 
-        try:
-            target = _locate(target)
-        except Exception as e:
-            msg = f"Error locating target '{target}', set env var HYDRA_FULL_ERROR=1 to see chained exception."
-            if full_key:
-                msg += f"\nfull_key: {full_key}"
-            raise InstantiationException(msg) from e
+            resolved_name = _get_os_alias_target(
+                _get_resolved_target_name_for_check(target)
+            )
+            if resolved_name != target_name:
+                _authorize_target_name(
+                    resolved_name,
+                    resolved_from,
+                    full_key,
+                    resolved_from_is_alias=True,
+                )
+
+        if resolved_name == "functools.partial":
+            _warn_direct_functools_partial_target()
     if not callable(target):
         msg = f"Expected a callable target, got '{target}' of type '{type(target).__name__}'"
         if full_key:

--- a/news/3410.bugfix
+++ b/news/3410.bugfix
@@ -1,0 +1,1 @@
+Harden instantiate authorization against unsafe aliases and callable results.

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -27,7 +27,14 @@ def partial_equal(obj1: Any, obj2: Any) -> bool:
 
     obj1, obj2 = _convert_type(obj1), _convert_type(obj2)
 
-    if type(obj1) != type(obj2):
+    if isinstance(obj1, partial) and isinstance(obj2, partial):
+        return all(
+            [
+                partial_equal(getattr(obj1, attr), getattr(obj2, attr))
+                for attr in ["func", "args", "keywords"]
+            ]
+        )
+    if type(obj1) is not type(obj2):
         return False
     if isinstance(obj1, dict):
         if len(obj1) != len(obj2):
@@ -40,14 +47,14 @@ def partial_equal(obj1: Any, obj2: Any) -> bool:
         if len(obj1) != len(obj2):
             return False
         return all([partial_equal(obj1[i], obj2[i]) for i in range(len(obj1))])
-    if not (isinstance(obj1, partial) and isinstance(obj2, partial)):
-        return False
-    return all(
-        [
-            partial_equal(getattr(obj1, attr), getattr(obj2, attr))
-            for attr in ["func", "args", "keywords"]
-        ]
-    )
+    return False
+
+
+def make_attributed_partial() -> partial:
+    result = partial(pow, exp=2)
+    result.__name__ = "square"
+    result.metadata = {"source": "application"}
+    return result
 
 
 class ArgsClass:

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -1,8 +1,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import builtins
+import contextlib
 import copy
 import os
 import pickle
 import re
+import types
+import _threading_local
 from dataclasses import dataclass
 from functools import partial
 from textwrap import dedent
@@ -13,6 +17,7 @@ from pytest import fixture, mark, param, raises, warns
 
 import hydra
 from hydra import version
+from hydra._internal.instantiate import _instantiate2
 from hydra._internal.instantiate._instantiate2 import _resolve_target
 from hydra.errors import Hydra14MigrationWarning, InstantiationException
 from hydra.test_utils.test_utils import assert_multiline_regex_search
@@ -1504,13 +1509,61 @@ def test_cannot_locate_target(instantiate_func: Any) -> None:
 @mark.parametrize(
     "target",
     [
+        "os.kill",
         "builtins.compile",
+        "builtins.__build_class__",
+        "builtins.classmethod",
+        "builtins.map",
+        "builtins.staticmethod",
+        "builtins.type.__call__",
+        "builtins.type.__new__",
+        "concurrent.futures.Executor.map",
+        "concurrent.futures.Executor.submit",
+        "concurrent.futures.ThreadPoolExecutor.map",
+        "concurrent.futures.ThreadPoolExecutor.submit",
+        "concurrent.futures.ProcessPoolExecutor.map",
+        "concurrent.futures.ProcessPoolExecutor.submit",
+        "contextlib.AsyncContextDecorator.__call__",
+        "contextlib.ContextDecorator.__call__",
+        "functools.cache",
+        "functools.lru_cache",
+        "functools.partialmethod",
+        "functools.partialmethod.__get__",
+        "functools.reduce",
+        "functools.singledispatch",
+        "functools.singledispatchmethod",
+        "functools.singledispatchmethod.__get__",
+        "functools.update_wrapper",
+        "functools.wraps",
+        "types.ClassMethodDescriptorType.__get__",
+        "types.FunctionType.__get__",
+        "types.MethodDescriptorType.__get__",
+        "types.FunctionType",
+        "types.MethodType",
+        "types.WrapperDescriptorType.__get__",
+        "types.new_class",
+        "unittest.mock.AsyncMock",
+        "unittest.mock.MagicMock",
+        "unittest.mock.Mock",
+        "unittest.mock.PropertyMock",
+        "unittest.mock.create_autospec",
+        "unittest.mock.mock_open",
+        "unittest.mock.patch",
+        "unittest.mock.patch.dict",
+        "unittest.mock.patch.multiple",
+        "unittest.mock.patch.object",
+        "itertools.accumulate",
+        "itertools.groupby",
+        "itertools.starmap",
+        "multiprocessing.pool.ThreadPool.apply",
+        "multiprocessing.pool.ThreadPool.apply_async",
+        "multiprocessing.pool.ThreadPool.starmap",
         "ctypes.CDLL",
         "ctypes.WinDLL",
         "ctypes.windll.LoadLibrary",
+        "dataclasses.make_dataclass",
         "importlib.import_module",
         "os.execl",
-        "os.getcwd",
         "os.popen",
         "os.posix_spawn",
         "posix.kill",
@@ -1529,42 +1582,725 @@ def test_blocklisted_target_fails(instantiate_func: Any, target: str) -> None:
     cfg = OmegaConf.create({"foo": {"_target_": target}})
     with raises(
         InstantiationException,
-        match=re.escape(dedent(f"""\
-                Target '{target}' is blocklisted and cannot be instantiated from config
-                to prevent security vulnerabilities, set env var
-                HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE={target}:<other allowlisted targets> to bypass
-                full_key: foo""")),
+        match="blocklisted",
     ) as exc_info:
         instantiate_func(cfg)
     err = exc_info.value
+    assert "full_key: foo" in str(err)
     assert hasattr(err, "__cause__")
     chained = err.__cause__
     assert chained is None
 
 
-def test_allowlist_works(instantiate_func: Any, monkeypatch: Any) -> None:
-    cfg = OmegaConf.create(
-        {
-            "foo": {"_target_": "builtins.exec", "_args_": ["5+8"]},
-            "bar": {"_target_": "builtins.eval", "_args_": ["1+2"]},
-        }
-    )
-    monkeypatch.setenv(
-        "HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "builtins.exec:builtins.eval"
-    )
-    res = instantiate_func(cfg)
-    assert res.foo is None
-    assert res.bar == 3
+def test_allowlist_override_works_for_general_target(monkeypatch: Any) -> None:
+    monkeypatch.setenv("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "os.kill")
+    assert _resolve_target("os.kill", "") is os.kill
 
 
-def test_allowlist_works_for_prefix_blocked_target(monkeypatch: Any) -> None:
+def test_allowlist_override_cannot_authorize_uncontrolled_prefix(
+    monkeypatch: Any,
+) -> None:
     monkeypatch.setenv("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "os.execl")
-    assert _resolve_target("os.execl", "") is os.execl
+    with raises(InstantiationException, match="cannot be authorized"):
+        _resolve_target("os.execl", "")
 
 
 def test_allowlist_works_for_canonical_os_alias(monkeypatch: Any) -> None:
     monkeypatch.setenv("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "os.kill")
     assert _resolve_target("posix.kill", "") is os.kill
+
+
+@mark.parametrize("target", sorted(_instantiate2.UNCONTROLLED_EXECUTION_TARGETS))
+def test_uncontrolled_execution_target_ignores_allowlist_override(
+    target: str, monkeypatch: Any
+) -> None:
+    monkeypatch.setenv("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", target)
+    with raises(InstantiationException, match="cannot be authorized"):
+        _resolve_target(target, "")
+
+
+@mark.parametrize(
+    "target",
+    [
+        "os.execl",
+        "os.spawnl",
+        "logging.config.valid_ident",
+        "doctest.OutputChecker",
+        "shelve.open",
+        "trace.main",
+        "pydoc.cram",
+        "pdb.help",
+        "bdb.Bdb",
+    ],
+)
+def test_uncontrolled_execution_family_ignores_allowlist_override(
+    target: str, monkeypatch: Any
+) -> None:
+    monkeypatch.setenv("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", target)
+    with raises(InstantiationException, match="cannot be authorized"):
+        _resolve_target(target, "")
+
+
+@mark.parametrize(
+    "target",
+    [
+        "doctest.DocTest",
+        "doctest.DocTestParser",
+        "doctest.Example",
+        "pydoc.HTMLDoc",
+        "pydoc.TextDoc",
+        "trace.Trace",
+    ],
+)
+def test_uncontrolled_execution_prefix_exceptions_are_not_blocklisted(
+    target: str,
+) -> None:
+    assert not _instantiate2._is_blocklisted_target(target)
+
+
+def test_blocklist_policy_sections_are_disjoint() -> None:
+    assert _instantiate2.DEFAULT_BLOCKLISTED_MODULES.isdisjoint(
+        _instantiate2.UNCONTROLLED_EXECUTION_TARGETS
+    )
+
+
+def test_getcwd_is_not_blocklisted() -> None:
+    assert _instantiate2.instantiate({"_target_": "os.getcwd"}) == os.getcwd()
+
+
+def test_ineffective_sys_modules_entries_are_not_in_policy() -> None:
+    for target in (
+        "sys.modules.ipdb",
+        "sys.modules.joblib",
+        "sys.modules.resource",
+        "sys.modules.psutil",
+        "sys.modules.tkinter",
+    ):
+        assert target not in _instantiate2.DEFAULT_BLOCKLISTED_MODULES
+        assert target not in _instantiate2.UNCONTROLLED_EXECUTION_TARGETS
+
+
+@mark.parametrize(
+    "alias",
+    [
+        "logging.os.system",
+        "logging.os.execl",
+        "multiprocessing.sharedctypes.ctypes.cdll.LoadLibrary",
+        "multiprocessing.sharedctypes.ctypes.pydll.LoadLibrary",
+        "site.builtins.exit",
+        "site.builtins.help",
+        "site.builtins.exit.__call__",
+        "site.builtins.help.__call__",
+        "site.builtins.exit.__call__.__call__",
+        "os.system.__call__",
+        "logging.os.system.__call__",
+        "builtins.eval.__call__",
+    ],
+)
+def test_blocklist_blocks_module_attribute_aliases(alias: str) -> None:
+    with raises(InstantiationException, match="blocklisted"):
+        _resolve_target(alias, "")
+
+
+@mark.parametrize(
+    "target",
+    [
+        os.system.__call__,
+        eval.__call__,
+        classmethod(getattr).__get__,
+        types.FunctionType,
+        types.MethodType,
+    ],
+)
+def test_blocklist_blocks_callable_object_aliases(target: Callable[..., Any]) -> None:
+    with raises(InstantiationException, match="blocklisted"):
+        _resolve_target(target, "")
+
+
+@mark.parametrize(
+    ("target", "canonical_target"),
+    [
+        ("operator.attrgetter.__new__", "operator.attrgetter"),
+        ("operator.itemgetter.__new__", "operator.itemgetter"),
+        ("operator.methodcaller.__new__", "operator.methodcaller"),
+        ("operator.attrgetter.__call__", "operator.attrgetter"),
+        ("operator.itemgetter.__call__", "operator.itemgetter"),
+        ("operator.methodcaller.__call__", "operator.methodcaller"),
+        ("builtins.map.__new__", "builtins.map"),
+        ("builtins.map.__call__", "builtins.map"),
+        ("builtins.map.__new__.__call__", "builtins.map"),
+        ("builtins.classmethod.__new__", "builtins.classmethod"),
+        ("builtins.classmethod.__new__.__call__", "builtins.classmethod"),
+        ("builtins.classmethod.__get__", "builtins.classmethod"),
+        ("builtins.classmethod.__get__.__call__", "builtins.classmethod"),
+        *(
+            [("builtins.classmethod.__call__", "builtins.classmethod")]
+            if hasattr(classmethod, "__call__")
+            else []
+        ),
+        ("builtins.staticmethod.__new__", "builtins.staticmethod"),
+        ("builtins.staticmethod.__new__.__call__", "builtins.staticmethod"),
+        *(
+            [("builtins.staticmethod.__call__", "builtins.staticmethod")]
+            if hasattr(staticmethod, "__call__")
+            else []
+        ),
+        ("builtins.type.__new__.__call__", "builtins.type.__new__"),
+        ("builtins.type.__call__.__call__", "builtins.type.__call__"),
+        (
+            "concurrent.futures.Executor.map",
+            "concurrent.futures._base.Executor.map",
+        ),
+        (
+            "concurrent.futures.Executor.submit",
+            "concurrent.futures._base.Executor.submit",
+        ),
+        (
+            "concurrent.futures.ThreadPoolExecutor.map",
+            "concurrent.futures._base.Executor.map",
+        ),
+        (
+            "concurrent.futures.ThreadPoolExecutor.submit",
+            "concurrent.futures.thread.ThreadPoolExecutor.submit",
+        ),
+        (
+            "concurrent.futures.ProcessPoolExecutor.map",
+            "concurrent.futures.process.ProcessPoolExecutor.map",
+        ),
+        (
+            "concurrent.futures.ProcessPoolExecutor.submit",
+            "concurrent.futures.process.ProcessPoolExecutor.submit",
+        ),
+        (
+            "contextlib._GeneratorContextManager.__call__",
+            "contextlib.ContextDecorator.__call__",
+        ),
+        (
+            "contextlib._GeneratorContextManager.__call__.__call__",
+            "contextlib.ContextDecorator.__call__",
+        ),
+        (
+            "contextlib._AsyncGeneratorContextManager.__call__",
+            "contextlib.AsyncContextDecorator.__call__",
+        ),
+        (
+            "contextlib._AsyncGeneratorContextManager.__call__.__call__",
+            "contextlib.AsyncContextDecorator.__call__",
+        ),
+        ("functools.reduce.__call__", "_functools.reduce"),
+        ("functools.partialmethod.__call__", "functools.partialmethod"),
+        (
+            "functools.partialmethod.__get__.__call__",
+            "functools.partialmethod.__get__",
+        ),
+        (
+            "functools.singledispatchmethod.__call__",
+            "functools.singledispatchmethod",
+        ),
+        (
+            "functools.singledispatchmethod.__get__.__call__",
+            "functools.singledispatchmethod.__get__",
+        ),
+        ("types.MethodType.__new__", "types.MethodType"),
+        ("types.MethodType.__call__", "types.MethodType"),
+        ("types.MethodType.__new__.__call__", "types.MethodType"),
+        ("types.FunctionType.__new__", "types.FunctionType"),
+        ("types.FunctionType.__call__", "types.FunctionType"),
+        ("types.FunctionType.__new__.__call__", "types.FunctionType"),
+        ("types.LambdaType", "types.FunctionType"),
+        (
+            "builtins.dict.get.__get__",
+            "types.MethodDescriptorType.__get__",
+        ),
+        (
+            "builtins.dict.get.__get__.__call__",
+            "types.MethodDescriptorType.__get__",
+        ),
+        (
+            "builtins.object.__getattribute__.__get__",
+            "types.WrapperDescriptorType.__get__",
+        ),
+        (
+            "multiprocessing.pool.ThreadPool._map_async",
+            "multiprocessing.pool.Pool._map_async",
+        ),
+        (
+            "multiprocessing.pool.ThreadPool.apply",
+            "multiprocessing.pool.Pool.apply",
+        ),
+        (
+            "multiprocessing.pool.ThreadPool.apply_async",
+            "multiprocessing.pool.Pool.apply_async",
+        ),
+        (
+            "multiprocessing.pool.ThreadPool.imap",
+            "multiprocessing.pool.Pool.imap",
+        ),
+        (
+            "multiprocessing.pool.ThreadPool.imap_unordered",
+            "multiprocessing.pool.Pool.imap_unordered",
+        ),
+        (
+            "multiprocessing.pool.ThreadPool.map",
+            "multiprocessing.pool.Pool.map",
+        ),
+        (
+            "multiprocessing.pool.ThreadPool.map_async",
+            "multiprocessing.pool.Pool.map_async",
+        ),
+        (
+            "multiprocessing.pool.ThreadPool.starmap",
+            "multiprocessing.pool.Pool.starmap",
+        ),
+        (
+            "multiprocessing.pool.ThreadPool.starmap_async",
+            "multiprocessing.pool.Pool.starmap_async",
+        ),
+        ("itertools.accumulate.__new__", "itertools.accumulate"),
+        ("itertools.accumulate.__call__", "itertools.accumulate"),
+        ("itertools.accumulate.__new__.__call__", "itertools.accumulate"),
+        ("itertools.groupby.__new__", "itertools.groupby"),
+        ("itertools.groupby.__call__", "itertools.groupby"),
+        ("itertools.groupby.__new__.__call__", "itertools.groupby"),
+        ("itertools.starmap.__new__", "itertools.starmap"),
+        ("itertools.starmap.__call__", "itertools.starmap"),
+        ("itertools.starmap.__new__.__call__", "itertools.starmap"),
+    ],
+)
+def test_resolved_target_aliases_are_blocklisted(
+    target: str, canonical_target: str
+) -> None:
+    with raises(
+        InstantiationException,
+        match=rf"Target '{canonical_target}'.*resolved from.*blocklisted",
+    ):
+        _resolve_target(target, "")
+
+
+@mark.parametrize(
+    "target",
+    [
+        "builtins.filter",
+        "builtins.iter",
+        "itertools.dropwhile",
+        "itertools.filterfalse",
+        "itertools.takewhile",
+    ],
+)
+def test_non_result_lazy_callback_targets_are_not_blocklisted(target: str) -> None:
+    assert not _instantiate2._is_blocklisted_target(target)
+
+
+def test_discovery_target_applies_blocklist_to_selected_path() -> None:
+    cfg = {"_target_": "hydra.utils.get_method", "path": "builtins.eval"}
+    with raises(InstantiationException, match="Target 'builtins.eval'.*blocklisted"):
+        _instantiate2.instantiate(cfg)
+
+
+def test_partial_discovery_target_applies_resolved_blocklist_when_invoked() -> None:
+    cfg = {
+        "_target_": "hydra.utils.get_method",
+        "_partial_": True,
+        "path": "logging.os.system",
+    }
+    deferred = _instantiate2.instantiate(cfg)
+
+    with raises(InstantiationException, match=r"Target 'os\.system'.*blocklisted"):
+        deferred()
+
+
+def test_partial_discovery_target_defers_resolution_and_allows_override() -> None:
+    cfg = {
+        "_target_": "hydra.utils.get_object",
+        "_partial_": True,
+        "path": "does.not.exist",
+    }
+    deferred = _instantiate2.instantiate(cfg)
+
+    assert deferred(path="builtins.pow") is pow
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.eval'.*blocklisted",
+    ):
+        deferred(path="builtins.eval")
+
+
+def test_partial_discovery_target_reauthorizes_runtime_override(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "os.remove")
+    deferred = _instantiate2.instantiate(
+        {
+            "_target_": "hydra.utils.get_object",
+            "_partial_": True,
+            "path": "os.remove",
+        }
+    )
+
+    assert deferred() is os.remove
+    with raises(InstantiationException, match=r"Target 'os\.kill'.*blocklisted"):
+        deferred(path="os.kill")
+
+
+def test_getattr_allows_non_callable_result() -> None:
+    cfg = {
+        "_target_": "builtins.getattr",
+        "_args_": [
+            {"_target_": "types.SimpleNamespace", "value": 10},
+            "value",
+        ],
+    }
+    assert _instantiate2.instantiate(cfg) == 10
+
+
+def test_getattr_callable_result_applies_blocklist() -> None:
+    cfg = {
+        "_target_": "builtins.getattr",
+        "_args_": [
+            {"_target_": "timeit.Timer", "stmt": "40 + 2"},
+            "timeit",
+        ],
+    }
+    with raises(
+        InstantiationException,
+        match=r"Target 'timeit\.Timer\.timeit'.*blocklisted",
+    ):
+        _instantiate2.instantiate(cfg)
+
+
+def test_callable_descriptor_binding_cannot_return_unmediated_selector() -> None:
+    cfg = {
+        "_target_": "builtins.dict.get.__get__",
+        "_args_": [{"eval": eval}],
+        "_convert_": "all",
+    }
+
+    with raises(
+        InstantiationException,
+        match=r"Target 'types\.MethodDescriptorType\.__get__'.*blocklisted",
+    ):
+        _instantiate2.instantiate(cfg)
+
+
+def test_classmethod_wrapper_cannot_defer_callable_selection() -> None:
+    cfg = {
+        "_target_": "builtins.classmethod",
+        "_args_": [getattr],
+    }
+
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.classmethod'.*blocklisted",
+    ):
+        _instantiate2.instantiate(cfg)
+
+
+def test_context_decorator_cannot_hide_deferred_callable_selection() -> None:
+    context_manager = _threading_local._patch(_threading_local.local())
+    wrapper = contextlib.ContextDecorator.__call__(context_manager, dict.get)
+    assert wrapper(vars(builtins), "eval") is eval
+
+    cfg = {
+        "_target_": "contextlib.ContextDecorator.__call__",
+        "_args_": [context_manager, dict.get],
+        "_convert_": "all",
+    }
+    with raises(
+        InstantiationException,
+        match=r"Target 'contextlib\.ContextDecorator\.__call__'.*blocklisted",
+    ):
+        _instantiate2.instantiate(cfg)
+
+
+def test_type_introspection_is_allowed() -> None:
+    assert _instantiate2.instantiate(
+        {"_target_": "builtins.type", "_args_": [10]}
+    ) is type(10)
+
+
+@mark.parametrize("target", ["builtins.type", "abc.ABCMeta"])
+def test_dynamic_type_construction_is_not_allowed(target: str) -> None:
+    cfg = {
+        "_target_": target,
+        "_args_": ["Selector", [], {"__call__": dict.get}],
+        "_convert_": "all",
+    }
+
+    with raises(
+        InstantiationException,
+        match="cannot be used for dynamic class construction",
+    ):
+        _instantiate2.instantiate(cfg)
+
+
+def test_partial_type_reauthorizes_runtime_arguments() -> None:
+    deferred = _instantiate2.instantiate(
+        {"_target_": "builtins.type", "_partial_": True}
+    )
+
+    assert deferred(10) is int
+    with raises(
+        InstantiationException,
+        match="cannot be used for dynamic class construction",
+    ):
+        deferred("Selector", (), {"__call__": dict.get})
+
+    deferred_metaclass = _instantiate2.instantiate(
+        {"_target_": "abc.ABCMeta", "_partial_": True}
+    )
+    with raises(
+        InstantiationException,
+        match="cannot be used for dynamic class construction",
+    ):
+        deferred_metaclass("Selector", (), {"__call__": dict.get})
+
+
+def test_metaclass_constructor_method_is_not_allowed() -> None:
+    with raises(
+        InstantiationException,
+        match="cannot be used for dynamic class construction",
+    ):
+        _instantiate2.instantiate({"_target_": "abc.ABCMeta.__new__"})
+
+    with raises(
+        InstantiationException,
+        match="cannot be used for dynamic class construction",
+    ):
+        _instantiate2.instantiate(
+            {"_target_": "abc.ABCMeta.__new__", "_partial_": True}
+        )
+
+
+def test_callable_mock_wrapper_is_not_allowed() -> None:
+    cfg = {
+        "_target_": "unittest.mock.Mock",
+        "side_effect": dict.get,
+    }
+
+    with raises(
+        InstantiationException,
+        match=r"Target 'unittest\.mock\.Mock'.*blocklisted",
+    ):
+        _instantiate2.instantiate(cfg)
+
+
+@mark.parametrize(
+    "target",
+    ["unittest.mock.NonCallableMock", "unittest.mock.NonCallableMagicMock"],
+)
+def test_non_callable_mock_is_allowed(target: str) -> None:
+    mock = _instantiate2.instantiate({"_target_": target, "name": "inert"})
+    assert not callable(mock)
+    assert mock._extract_mock_name() == "inert"
+
+
+def test_non_callable_mock_allows_one_positional_spec() -> None:
+    mock = _instantiate2.instantiate(
+        {
+            "_target_": "unittest.mock.NonCallableMock",
+            "_args_": [[]],
+        }
+    )
+    assert not callable(mock)
+
+
+@mark.parametrize(
+    "unsafe_kwargs",
+    [
+        {"child": dict.get},
+        {"child.side_effect": dict.get},
+        {"wraps": {}},
+    ],
+)
+def test_non_callable_mock_cannot_configure_callable_children(
+    unsafe_kwargs: Dict[str, Any],
+) -> None:
+    cfg = {"_target_": "unittest.mock.NonCallableMock", **unsafe_kwargs}
+    with raises(
+        InstantiationException,
+        match="cannot configure callable attributes",
+    ):
+        _instantiate2.instantiate(cfg)
+
+
+def test_partial_non_callable_mock_reauthorizes_runtime_configuration() -> None:
+    deferred = _instantiate2.instantiate(
+        {"_target_": "unittest.mock.NonCallableMock", "_partial_": True}
+    )
+    assert not callable(deferred(name="inert"))
+    with raises(
+        InstantiationException,
+        match="cannot configure callable attributes",
+    ):
+        deferred(**{"child.side_effect": dict.get})
+    with raises(
+        InstantiationException,
+        match="cannot configure callable attributes",
+    ):
+        deferred(None, {})
+
+
+def test_non_callable_mock_rejects_positional_wraps() -> None:
+    cfg = {
+        "_target_": "unittest.mock.NonCallableMock",
+        "_args_": [None, {}],
+    }
+    with raises(
+        InstantiationException,
+        match="cannot configure callable attributes",
+    ):
+        _instantiate2.instantiate(cfg)
+
+
+def test_callable_result_from_any_target_applies_blocklist() -> None:
+    cfg = {
+        "_target_": "builtins.dict.get",
+        "_args_": [{"eval": eval}, "eval"],
+        "_convert_": "all",
+    }
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.eval'.*blocklisted",
+    ):
+        _instantiate2.instantiate(cfg)
+
+
+def test_callable_result_from_any_target_allows_safe_callable() -> None:
+    cfg = {
+        "_target_": "builtins.dict.get",
+        "_args_": [{"pow": pow}, "pow"],
+        "_convert_": "all",
+    }
+    assert _instantiate2.instantiate(cfg) is pow
+
+
+def test_callable_result_producer_allowlist_does_not_authorize_result(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv(
+        "HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE",
+        "builtins.dict.get",
+    )
+    cfg = {
+        "_target_": "builtins.dict.get",
+        "_args_": [{"remove": os.remove}, "remove"],
+        "_convert_": "all",
+    }
+
+    with raises(InstantiationException, match=r"Target 'os\.remove'.*blocklisted"):
+        _instantiate2.instantiate(cfg)
+
+
+def test_discovery_result_accepts_allowlisted_alias(monkeypatch: Any) -> None:
+    monkeypatch.setenv(
+        "HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE",
+        "logging.os.kill",
+    )
+    cfg = {
+        "_target_": "hydra.utils.get_method",
+        "path": "logging.os.kill",
+    }
+
+    assert _instantiate2.instantiate(cfg) is os.kill
+
+
+def test_hydra_partial_authorizes_callable_result_when_invoked() -> None:
+    cfg = {
+        "_target_": "builtins.getattr",
+        "_partial_": True,
+        "_args_": [
+            {"_target_": "hydra.utils.get_object", "path": "builtins"},
+        ],
+    }
+    deferred = _instantiate2.instantiate(cfg)
+
+    assert isinstance(deferred, partial)
+    assert deferred.func is getattr
+    assert deferred("pow") is pow
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.eval'.*blocklisted",
+    ):
+        deferred("eval")
+
+
+def test_hydra_partial_with_runtime_authorization_is_pickleable() -> None:
+    deferred = _instantiate2.instantiate(
+        {"_target_": "builtins.pow", "_partial_": True, "exp": 2}
+    )
+    restored = pickle.loads(pickle.dumps(deferred))
+
+    assert isinstance(restored, partial)
+    assert restored.func is pow
+    assert restored(3) == 9
+
+
+def test_direct_functools_partial_warns() -> None:
+    cfg = {"_target_": "functools.partial", "_args_": [pow], "exp": 2}
+    with warns(UserWarning, match=r"Using '_target_: functools\.partial'"):
+        factory = _instantiate2.instantiate(cfg)
+    assert factory(3) == 9
+
+
+def test_direct_functools_partial_applies_blocklist_to_callable() -> None:
+    cfg = {"_target_": "functools.partial", "_args_": [eval]}
+    with warns(UserWarning, match=r"Using '_target_: functools\.partial'"):
+        with raises(
+            InstantiationException, match=r"Target 'builtins\.eval'.*blocklisted"
+        ):
+            _instantiate2.instantiate(cfg)
+
+
+def test_direct_functools_partial_authorizes_callable_result_when_invoked() -> None:
+    cfg = {
+        "_target_": "functools.partial",
+        "_args_": [
+            getattr,
+            {"_target_": "hydra.utils.get_object", "path": "builtins"},
+        ],
+    }
+    with warns(UserWarning, match=r"Using '_target_: functools\.partial'"):
+        factory = _instantiate2.instantiate(cfg)
+
+    assert isinstance(factory, partial)
+    assert factory("pow") is pow
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.eval'.*blocklisted",
+    ):
+        factory("eval")
+
+
+def test_hydra_partial_mediates_partial_result_when_invoked() -> None:
+    cfg = {
+        "_target_": "functools.partial",
+        "_partial_": True,
+        "_args_": [
+            getattr,
+            {"_target_": "hydra.utils.get_object", "path": "builtins"},
+        ],
+    }
+    with warns(UserWarning, match=r"Using '_target_: functools\.partial'"):
+        outer = _instantiate2.instantiate(cfg)
+
+    inner = outer()
+    assert isinstance(inner, partial)
+    assert inner("pow") is pow
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.eval'.*blocklisted",
+    ):
+        inner("eval")
+
+
+def test_mediated_partial_result_preserves_attributes() -> None:
+    factory = _instantiate2.instantiate(
+        {"_target_": "tests.instantiate.make_attributed_partial"}
+    )
+
+    assert factory.__name__ == "square"
+    assert factory.metadata == {"source": "application"}
+    assert factory(3) == 9
 
 
 @mark.parametrize(


### PR DESCRIPTION
## Summary

- backport the instantiate target-authorization hardening from #3412 to Hydra 1.3
- separate generally problematic targets from uncontrolled-execution surfaces, which `HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE` cannot authorize
- check canonical callable aliases and apply target policy to callable results from every invoked target
- allow `resolved_from` to satisfy an override only for genuine alias resolution, never merely because an allowlisted producer returned another callable
- deny the bounded callback-execution family across builtin, executor, multiprocessing pool, and functools/itertools apply/map/reduce/submit-style APIs, including inherited/public/canonical aliases
- deny callable-producing, binding, reconstructing, and relabeling surfaces (`classmethod`, `staticmethod`, `ContextDecorator`, `AsyncContextDecorator`, `cache`, `lru_cache`, `partialmethod`, `singledispatch`, `singledispatchmethod`, `update_wrapper`, `wraps`, `types.FunctionType`, `types.MethodType`, and callable descriptor binders) whose later calls escape result mediation or execute code under a forged identity
- deny callable `unittest.mock` constructors/factories and patch mutation helpers while retaining non-callable mocks only for one positional `spec` or inert `name`/`spec`/`spec_set` keyword configuration
- preserve one-argument `type(obj)` introspection while rejecting dynamic class construction through `type`, metaclass subclasses and constructor overrides, and generic `type.__new__`/`type.__call__`/`new_class`/`__build_class__`/`make_dataclass` surfaces
- retain predicate-only iterators and `builtins.iter`, which do not fit that bounded execution/result-exposure rule
- mediate exact `functools.partial` results from every target with invocation-time authorization, preserving application attributes while rejecting partial subclasses
- preserve lazy discovery-partial resolution while reauthorizing the effective path on every invocation and runtime override
- retain 1.3 compatibility without introducing the 1.4 target-whitelist API

Refs #3410.

## Verification

- Python 3.11 instantiate suite: 750 passed
- focused target-policy and alias suite: 285 passed
- indexed public YAML searches found no uses of the checked executor classes or executor-map targets
- reported callback dispatcher and callable-wrapper chains are rejected at their targets
- `builtins.staticmethod` and its constructor/call aliases are denied before they can defer an unauthorized callable result
- `builtins.classmethod` construction and binding aliases are denied before a non-callable descriptor can later expose an unmediated callable
- callable function/method/wrapper/classmethod descriptor binders and concrete nested aliases are denied without blocking value descriptors
- `functools.singledispatchmethod` construction and descriptor binding are denied before producing an unmediated dispatch wrapper
- `functools.partialmethod` construction and descriptor binding are denied before producing an unmediated partial wrapper
- synchronous and asynchronous context-decorator wrapper factories, including inherited generator-context-manager aliases, are denied before copied callable identities can hide deferred results
- `types.MethodType` constructor aliases are denied without rejecting ordinary bound-method results
- `types.FunctionType`/`LambdaType` constructor and call aliases are denied without rejecting ordinary function results
- direct and Hydra-partial `builtins.type`/metaclass calls reject dynamic class construction at invocation time while ordinary classes remain unaffected
- overridden metaclass constructor methods and `dataclasses.make_dataclass` are denied as equivalent generated-class surfaces
- callable mocks with deferred `side_effect`/`wraps` execution are denied; non-callable mocks reject positional `wraps`, arbitrary attributes, dotted children, and wrappers on direct and deferred calls
- producer allowlisting does not authorize a different returned callable; explicitly allowlisted genuine aliases still work
- exact partial results are wrapped for invocation-time checks, preserve custom attributes, allow `pow`, and reject `eval`
- discovery partial runtime overrides are authorized independently of their configured defaults
- direct legacy partial invocation allows safe callable results and rejects `builtins.eval`
- discovery partials defer unavailable defaults, accept safe runtime overrides, and reject unsafe resolved callables
- Ruff passes for the changed source and test files
- broad Python 3.11 core run: 2603 passed, 216 skipped, 1 xfailed; one unrelated Packaging 25 exception-expectation failure remains

Release and advisory coordination are intentionally separate from this PR.
