### PR TITLE
Reject conflicting Defaults List keywords

### DIFF
--- a/hydra/_internal/config_repository.py
+++ b/hydra/_internal/config_repository.py
@@ -298,6 +298,11 @@ class ConfigRepository(IConfigRepository):
                 keywords.optional = True
             elif keyword == "override":
                 keywords.override = True
+        if keywords.optional and keywords.override:
+            raise ValueError(
+                f"In {config_path}: 'optional' and 'override' keywords "
+                "cannot be combined in defaults list"
+            )
         keywords.group = group
 
 

--- a/news/3405.bugfix
+++ b/news/3405.bugfix
@@ -1,0 +1,1 @@
+Reject Defaults List entries that combine `optional` and `override`.

--- a/tests/defaults_list/data/conflicting_keywords.yaml
+++ b/tests/defaults_list/data/conflicting_keywords.yaml
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Contributors to Hydra
+# SPDX-License-Identifier: MIT
+
+defaults:
+  - optional override group1: file1

--- a/tests/defaults_list/data/conflicting_keywords_reversed.yaml
+++ b/tests/defaults_list/data/conflicting_keywords_reversed.yaml
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Contributors to Hydra
+# SPDX-License-Identifier: MIT
+
+defaults:
+  - override optional group1: file1

--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -105,6 +105,21 @@ def test_unknown_keyword_in_defaults_list() -> None:
         repo.load_config(config_path="unknown_keyword")
 
 
+@mark.parametrize(
+    "config_path", ["conflicting_keywords", "conflicting_keywords_reversed"]
+)
+def test_conflicting_keywords_in_defaults_list(config_path: str) -> None:
+    repo = create_repo()
+    with raises(
+        ValueError,
+        match=re.escape(
+            f"In {config_path}: 'optional' and 'override' keywords "
+            "cannot be combined in defaults list"
+        ),
+    ):
+        repo.load_config(config_path=config_path)
+
+
 @mark.parametrize("config_name", ["empty_group", "whitespace_group"])
 def test_missing_group_name_in_defaults_list(config_name: str) -> None:
     repo = create_repo()


### PR DESCRIPTION
## Motivation

The documented Defaults List grammar allows either `optional` or `override`, but the parser currently accepts both on one group default. The combined form is only partially honored and fails inconsistently when the selected option is missing.

This change rejects the conflicting pair during Defaults List parsing. The error identifies both keywords and the containing config, while standalone keyword behavior is unchanged. Regression fixtures cover both keyword orders, and a bugfix news fragment records the behavior change.

### Have you read the Contributing Guidelines on pull requests?

Yes.

### For non-trivial features, API changes, or behavior changes: is there an issue or design discussion where maintainers agreed on the direction?

Issue #3405 defines the invalid form, expected rejection behavior, and compatibility window.

## Test Plan

- `pytest -q tests/defaults_list/test_defaults_list.py` — 140 passed
- `pytest -q tests/defaults_list/test_defaults_tree.py` — 196 passed
- `pytest -q tests --ignore=tests/test_completion.py` — 2,602 passed
- `pytest -q tests/test_completion.py` — 651 passed, 73 skipped, 17 xfailed
- Ruff check and format verification for the changed Python files
- Pyrefly check for the changed Python files
- Strict YAML lint for both new fixtures
- Towncrier draft rendering and `git diff --check`

## Related Issues and PRs

Fixes #3405.
