### PR TITLE
Backport instantiate authorization hardening to 1.4

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -3,8 +3,10 @@
 import copy
 import functools
 import inspect
+import itertools
 import operator
 import re
+import types
 from contextvars import ContextVar
 from enum import Enum
 from textwrap import dedent
@@ -65,120 +67,202 @@ DEFAULT_BLOCKLISTED_MODULES = {
     "shutil.chown",
 }
 
+# These dispatchers execute caller-supplied callables and return their results
+# directly or through a container, iterator, or deferred result. That allows
+# selection, wrapping, and invocation to happen outside instantiate's immediate
+# callable-result authorization.
+CALLBACK_DISPATCH_TARGETS = {
+    "builtins.map",
+    "concurrent.futures._base.Executor.map",
+    "concurrent.futures._base.Executor.submit",
+    "concurrent.futures.process.ProcessPoolExecutor.map",
+    "concurrent.futures.process.ProcessPoolExecutor.submit",
+    "concurrent.futures.thread.ThreadPoolExecutor.submit",
+    "functools.partial.__call__",
+    "functools.reduce",
+    "itertools.accumulate",
+    "itertools.groupby",
+    "itertools.starmap",
+    "multiprocessing.pool.Pool._map_async",
+    "multiprocessing.pool.Pool.apply",
+    "multiprocessing.pool.Pool.apply_async",
+    "multiprocessing.pool.Pool.imap",
+    "multiprocessing.pool.Pool.imap_unordered",
+    "multiprocessing.pool.Pool.map",
+    "multiprocessing.pool.Pool.map_async",
+    "multiprocessing.pool.Pool.starmap",
+    "multiprocessing.pool.Pool.starmap_async",
+    "_functools.reduce",
+}
+
+_CALLABLE_DESCRIPTOR_BINDING_TARGETS: Dict[type, str] = {
+    property: "builtins.property.__get__",
+    types.ClassMethodDescriptorType: "types.ClassMethodDescriptorType.__get__",
+    types.FunctionType: "types.FunctionType.__get__",
+    types.MethodDescriptorType: "types.MethodDescriptorType.__get__",
+    types.WrapperDescriptorType: "types.WrapperDescriptorType.__get__",
+}
+
+# These helpers construct, bind, or relabel callable wrappers whose later
+# invocation can return an unauthorized callable outside instantiate's result
+# mediation.
+CALLABLE_WRAPPER_TARGETS = {
+    "builtins.classmethod",
+    "builtins.staticmethod",
+    "contextlib.AsyncContextDecorator.__call__",
+    "contextlib.ContextDecorator.__call__",
+    "functools.cache",
+    "functools.lru_cache",
+    "functools.partialmethod",
+    "functools.partialmethod.__get__",
+    "functools.singledispatch",
+    "functools.singledispatchmethod",
+    "functools.singledispatchmethod.__get__",
+    "functools.update_wrapper",
+    "functools.wraps",
+    "types.FunctionType",
+    "types.MethodType",
+    "unittest.mock.AsyncMock",
+    "unittest.mock.MagicMock",
+    "unittest.mock.Mock",
+    "unittest.mock.PropertyMock",
+    "unittest.mock.create_autospec",
+    "unittest.mock.mock_open",
+} | set(_CALLABLE_DESCRIPTOR_BINDING_TARGETS.values())
+
+_NON_CALLABLE_MOCK_TARGETS = {
+    "unittest.mock.NonCallableMagicMock",
+    "unittest.mock.NonCallableMock",
+}
+_NON_CALLABLE_MOCK_SAFE_PARAMETERS = {"name", "spec", "spec_set"}
+
 # These targets allow config data to select or supply executable behavior.
 # They are refused both on the legacy path and by a real target whitelist.
 # UNSAFE_ALLOW_ALL_TARGETS remains the explicit opt-out from all checks.
-UNCONTROLLED_EXECUTION_TARGETS = {
-    "_sitebuiltins._Helper",
-    "builtins.__import__",
-    "builtins.compile",
-    "builtins.eval",
-    "builtins.exec",
-    "builtins.help",
-    # Generic dispatch primitives delegate the effective callable, selected
-    # member, or operation to config data instead of naming it as _target_.
-    # Include public and canonical C-module spellings.
-    "operator.attrgetter",
-    "operator.call",
-    "operator.contains",
-    "operator.delitem",
-    "operator.getitem",
-    "operator.itemgetter",
-    "operator.methodcaller",
-    "operator.setitem",
-    "_operator.attrgetter",
-    "_operator.call",
-    "_operator.contains",
-    "_operator.delitem",
-    "_operator.getitem",
-    "_operator.itemgetter",
-    "_operator.methodcaller",
-    "_operator.setitem",
-    "ctypes.CDLL",
-    "ctypes.LibraryLoader.LoadLibrary",
-    "ctypes.OleDLL",
-    "ctypes.PyDLL",
-    "ctypes.WinDLL",
-    "ctypes.cdll.LoadLibrary",
-    "ctypes.oledll.LoadLibrary",
-    "ctypes.pydll.LoadLibrary",
-    "ctypes.windll.LoadLibrary",
-    "importlib.import_module",
-    "importlib.machinery.ExtensionFileLoader.create_module",
-    "importlib.machinery.ExtensionFileLoader.exec_module",
-    "importlib.machinery.ExtensionFileLoader.load_module",
-    "importlib.machinery.SourceFileLoader.exec_module",
-    "importlib.machinery.SourceFileLoader.load_module",
-    "importlib.machinery.SourcelessFileLoader.exec_module",
-    "importlib.machinery.SourcelessFileLoader.load_module",
-    "_frozen_importlib_external.ExtensionFileLoader.create_module",
-    "_frozen_importlib_external.ExtensionFileLoader.exec_module",
-    "_frozen_importlib_external.FileLoader.load_module",
-    "_frozen_importlib_external._LoaderBasics.exec_module",
-    "os.popen",
-    "os.posix_spawn",
-    "os.posix_spawnp",
-    "os.startfile",
-    "os.system",
-    "pty.spawn",
-    "runpy.run_module",
-    "runpy.run_path",
-    "subprocess.Popen",
-    "subprocess.call",
-    "subprocess.check_call",
-    "subprocess.check_output",
-    "subprocess.getoutput",
-    "subprocess.getstatusoutput",
-    "subprocess.run",
-    # Unsafe deserialization sinks. Include friendly and canonical C spellings
-    # so resolved identities such as pickle.loads -> _pickle.loads are caught.
-    "pickle.load",
-    "pickle.loads",
-    "pickle.Unpickler",
-    "pickle._load",
-    "pickle._loads",
-    "pickle._Unpickler",
-    "_pickle.load",
-    "_pickle.loads",
-    "_pickle.Unpickler",
-    "marshal.load",
-    "marshal.loads",
-    "tracemalloc.Snapshot.load",
-    "dill.load",
-    "dill.loads",
-    "cloudpickle.load",
-    "cloudpickle.loads",
-    # Exec/eval wrappers that run config-supplied strings or code objects.
-    "timeit.timeit",
-    "timeit.repeat",
-    "timeit.main",
-    "timeit.Timer.timeit",
-    "timeit.Timer.repeat",
-    "timeit.Timer.autorange",
-    "cProfile.run",
-    "cProfile.runctx",
-    "cProfile.Profile.run",
-    "cProfile.Profile.runctx",
-    "profile.run",
-    "profile.runctx",
-    "profile.Profile.run",
-    "profile.Profile.runctx",
-    "code.interact",
-    "code.InteractiveInterpreter.runsource",
-    "code.InteractiveInterpreter.runcode",
-    "code.InteractiveConsole.push",
-    # Annotation evaluators: these execute string annotations as expressions.
-    # Include compatibility and canonical spellings across Python versions.
-    "typing.ForwardRef._evaluate",
-    "typing._eval_type",
-    "typing.evaluate_forward_ref",
-    "typing.get_type_hints",
-    "annotationlib.ForwardRef._evaluate",
-    "annotationlib.ForwardRef.evaluate",
-    "annotationlib.get_annotations",
-    "optparse.Values.read_file",
-    "optparse.Values.read_module",
-}
+UNCONTROLLED_EXECUTION_TARGETS = (
+    {
+        "_sitebuiltins._Helper",
+        "builtins.__build_class__",
+        "builtins.__import__",
+        "builtins.compile",
+        "builtins.eval",
+        "builtins.exec",
+        "builtins.help",
+        "builtins.type.__call__",
+        "builtins.type.__new__",
+        # Generic dispatch primitives delegate the effective callable, selected
+        # member, or operation to config data instead of naming it as _target_.
+        # Include public and canonical C-module spellings.
+        "operator.attrgetter",
+        "operator.call",
+        "operator.contains",
+        "operator.delitem",
+        "operator.getitem",
+        "operator.itemgetter",
+        "operator.methodcaller",
+        "operator.setitem",
+        "_operator.attrgetter",
+        "_operator.call",
+        "_operator.contains",
+        "_operator.delitem",
+        "_operator.getitem",
+        "_operator.itemgetter",
+        "_operator.methodcaller",
+        "_operator.setitem",
+        "ctypes.CDLL",
+        "ctypes.LibraryLoader.LoadLibrary",
+        "ctypes.OleDLL",
+        "ctypes.PyDLL",
+        "ctypes.WinDLL",
+        "ctypes.cdll.LoadLibrary",
+        "ctypes.oledll.LoadLibrary",
+        "ctypes.pydll.LoadLibrary",
+        "ctypes.windll.LoadLibrary",
+        "dataclasses.make_dataclass",
+        "importlib.import_module",
+        "importlib.machinery.ExtensionFileLoader.create_module",
+        "importlib.machinery.ExtensionFileLoader.exec_module",
+        "importlib.machinery.ExtensionFileLoader.load_module",
+        "importlib.machinery.SourceFileLoader.exec_module",
+        "importlib.machinery.SourceFileLoader.load_module",
+        "importlib.machinery.SourcelessFileLoader.exec_module",
+        "importlib.machinery.SourcelessFileLoader.load_module",
+        "_frozen_importlib_external.ExtensionFileLoader.create_module",
+        "_frozen_importlib_external.ExtensionFileLoader.exec_module",
+        "_frozen_importlib_external.FileLoader.load_module",
+        "_frozen_importlib_external._LoaderBasics.exec_module",
+        "os.popen",
+        "os.posix_spawn",
+        "os.posix_spawnp",
+        "os.startfile",
+        "os.system",
+        "pty.spawn",
+        "runpy.run_module",
+        "runpy.run_path",
+        "subprocess.Popen",
+        "subprocess.call",
+        "subprocess.check_call",
+        "subprocess.check_output",
+        "subprocess.getoutput",
+        "subprocess.getstatusoutput",
+        "subprocess.run",
+        # Unsafe deserialization sinks. Include friendly and canonical C spellings
+        # so resolved identities such as pickle.loads -> _pickle.loads are caught.
+        "pickle.load",
+        "pickle.loads",
+        "pickle.Unpickler",
+        "pickle._load",
+        "pickle._loads",
+        "pickle._Unpickler",
+        "_pickle.load",
+        "_pickle.loads",
+        "_pickle.Unpickler",
+        "marshal.load",
+        "marshal.loads",
+        "tracemalloc.Snapshot.load",
+        "dill.load",
+        "dill.loads",
+        "cloudpickle.load",
+        "cloudpickle.loads",
+        # Exec/eval wrappers that run config-supplied strings or code objects.
+        "timeit.timeit",
+        "timeit.repeat",
+        "timeit.main",
+        "timeit.Timer.timeit",
+        "timeit.Timer.repeat",
+        "timeit.Timer.autorange",
+        "cProfile.run",
+        "cProfile.runctx",
+        "cProfile.Profile.run",
+        "cProfile.Profile.runctx",
+        "profile.run",
+        "profile.runctx",
+        "profile.Profile.run",
+        "profile.Profile.runctx",
+        "code.interact",
+        "code.InteractiveInterpreter.runsource",
+        "code.InteractiveInterpreter.runcode",
+        "code.InteractiveConsole.push",
+        # Annotation evaluators: these execute string annotations as expressions.
+        # Include compatibility and canonical spellings across Python versions.
+        "typing.ForwardRef._evaluate",
+        "typing._eval_type",
+        "typing.evaluate_forward_ref",
+        "typing.get_type_hints",
+        "types.new_class",
+        "unittest.mock.patch",
+        "unittest.mock.patch.dict",
+        "unittest.mock.patch.multiple",
+        "unittest.mock.patch.object",
+        "annotationlib.ForwardRef._evaluate",
+        "annotationlib.ForwardRef.evaluate",
+        "annotationlib.get_annotations",
+        "optparse.Values.read_file",
+        "optparse.Values.read_module",
+    }
+    | CALLBACK_DISPATCH_TARGETS
+    | CALLABLE_WRAPPER_TARGETS
+)
 
 # These package families contain version-specific execution, import, debugger,
 # or unsafe loading surfaces. Prefixes make coverage version-resilient; narrow
@@ -255,19 +339,17 @@ DISCOVERY_TARGETS = {
     "hydra.utils.get_object",
 }
 
-# These targets may return a callable selected by config data. Non-callable
-# results remain ordinary values; callable results must independently satisfy
-# the active target policy before they can flow into another config target.
-CALLABLE_RESULT_TARGETS = {
-    "builtins.getattr",
-    "functools.partial",
-}
-DEFERRED_CALLABLE_SELECTION_TARGETS = DISCOVERY_TARGETS | CALLABLE_RESULT_TARGETS
-
 
 class _UnsafeAllowAllTargets:
     def __repr__(self) -> str:
         return "UNSAFE_ALLOW_ALL_TARGETS"
+
+    def __reduce__(self) -> Any:
+        return (_get_unsafe_allow_all_targets, ())
+
+
+def _get_unsafe_allow_all_targets() -> "_UnsafeAllowAllTargets":
+    return UNSAFE_ALLOW_ALL_TARGETS
 
 
 UNSAFE_ALLOW_ALL_TARGETS = _UnsafeAllowAllTargets()
@@ -568,45 +650,31 @@ def _call_target(
         raise InstantiationException(_with_full_key(msg, full_key)) from e
 
     resolved_target_name = _get_resolved_target_name_for_check(_target_)
-    if (
-        _partial_
-        and resolved_target_name in DEFERRED_CALLABLE_SELECTION_TARGETS
-        and target_whitelist is not None
-        and target_whitelist is not UNSAFE_ALLOW_ALL_TARGETS
-    ):
-        msg = dedent(
-            f"""\
-            Target '{resolved_target_name}' cannot use '_partial_: true' with the
-            instantiate target whitelist because its effective callable could be
-            selected after authorization. Resolve the callable immediately or use a
-            trusted Python wrapper."""
-        )
-        raise InstantiationException(_with_full_key(msg, full_key))
-
-    discovery_path = _authorize_discovery_path(
-        _target_, args, kwargs, full_key, target_whitelist
+    effective_target, effective_args, effective_kwargs = (
+        _get_effective_target_invocation(_target_, args, kwargs)
     )
-    # For a deferred discovery partial on the legacy path, eagerly resolve and
-    # blocklist-check the selected target so a partial cannot smuggle a blocked
-    # callable past the stopgap. UNSAFE_ALLOW_ALL_TARGETS opts out of all checks
-    # and keeps discovery fully deferred.
-    if (
-        discovery_path is not None
-        and _partial_
-        and target_whitelist is not UNSAFE_ALLOW_ALL_TARGETS
-    ):
-        try:
-            discovered = _locate(discovery_path)
-        except Exception as e:
-            msg = f"Error locating discovered target '{discovery_path}'"
-            raise InstantiationException(_with_full_key(msg, full_key)) from e
-        if callable(discovered):
-            _authorize_discovery_result(
-                discovery_path, discovered, full_key, target_whitelist
-            )
+    _authorize_target_invocation(
+        effective_target,
+        effective_args,
+        effective_kwargs,
+        full_key,
+        target_whitelist,
+        allow_incomplete_partial=_partial_,
+    )
+    discovery_path = _authorize_discovery_path(
+        effective_target,
+        effective_args,
+        effective_kwargs,
+        full_key,
+        target_whitelist,
+    )
     try:
         if _partial_:
-            return functools.partial(_target_, *args, **kwargs)
+            deferred = _DeferredTarget(_target_, *args, **kwargs)
+            deferred._hydra_resolved_from = discovery_path or resolved_target_name
+            deferred._hydra_full_key = full_key
+            deferred._hydra_target_whitelist = target_whitelist
+            return deferred
         result = _target_(*args, **kwargs)
     except Exception as e:
         if _partial_:
@@ -618,33 +686,13 @@ def _call_target(
             msg = f"Error in call to target '{_convert_target_to_string(_target_)}':\n{repr(e)}"
         raise InstantiationException(_with_full_key(msg, full_key)) from e
 
-    if discovery_path is not None and callable(result):
-        _authorize_discovery_result(discovery_path, result, full_key, target_whitelist)
-    if resolved_target_name == "builtins.getattr" and callable(result):
-        _authorize_callable_result(
-            result, resolved_target_name, full_key, target_whitelist
-        )
-    if resolved_target_name == "functools.partial" and isinstance(
-        result, functools.partial
-    ):
-        if (
-            target_whitelist is not UNSAFE_ALLOW_ALL_TARGETS
-            and type(result) is not functools.partial
-        ):
-            msg = dedent(
-                """\
-                Direct functools.partial targets cannot construct partial subclasses
-                because overrides can hide their invocation behavior. Set '_target_'
-                to the effective callable and use '_partial_: true' instead."""
-            )
-            raise InstantiationException(_with_full_key(msg, full_key))
-        _authorize_callable_result(
-            functools.partial.func.__get__(result),
-            resolved_target_name,
-            full_key,
-            target_whitelist,
-        )
-    return result
+    return _mediate_target_result(
+        result,
+        discovery_path or resolved_target_name,
+        full_key,
+        target_whitelist,
+        discovery_path=discovery_path,
+    )
 
 
 def _convert_target_to_string(t: Any) -> Any:
@@ -668,10 +716,9 @@ def _get_target_name_for_check(target: Union[str, type, Callable[..., Any]]) -> 
 def _get_resolved_target_name_for_check(target: Callable[..., Any]) -> str:
     """Return the security identity of a resolved callable.
 
-    Bound ``__call__`` attributes, ``functools.partial`` objects, and unbound
-    descriptors owned by denied operator types must be authorized as the
-    callable they wrap or expose, not as generic callable containers. Unwrap
-    recursively because either wrapper form can wrap the other.
+    Callable wrappers, constructors, and descriptors must be authorized as the
+    operation they expose, not as generic callable containers. Unwrap recursively
+    because wrapper forms can wrap one another.
     """
     seen: set[int] = set()
     while id(target) not in seen:
@@ -690,20 +737,65 @@ def _get_resolved_target_name_for_check(target: Callable[..., Any]) -> str:
     if target is type.__getattribute__:
         return "builtins.type.__getattribute__"
     descriptor_owner = getattr(target, "__objclass__", None)
+    if getattr(target, "__name__", None) == "__get__":
+        descriptor_binding_target = (
+            _CALLABLE_DESCRIPTOR_BINDING_TARGETS.get(descriptor_owner)
+            if isinstance(descriptor_owner, type)
+            else None
+        )
+        if descriptor_binding_target is not None:
+            return descriptor_binding_target
     if descriptor_owner is operator.attrgetter:
         return "operator.attrgetter"
     if descriptor_owner is operator.itemgetter:
         return "operator.itemgetter"
     if descriptor_owner is operator.methodcaller:
         return "operator.methodcaller"
+    if descriptor_owner is type and getattr(target, "__name__", None) == "__call__":
+        return "builtins.type.__call__"
+    if descriptor_owner is types.FunctionType:
+        return "types.FunctionType"
+    if descriptor_owner is types.MethodType:
+        return "types.MethodType"
+    if descriptor_owner is classmethod:
+        return "builtins.classmethod"
+    if descriptor_owner is staticmethod:
+        return "builtins.staticmethod"
     if target is functools.partial.__new__:
         return "functools.partial"
+    if target is type.__new__:
+        return "builtins.type.__new__"
+    if target is classmethod or target is classmethod.__new__:
+        return "builtins.classmethod"
+    if target is staticmethod or target is staticmethod.__new__:
+        return "builtins.staticmethod"
+    if target is types.FunctionType or target is types.FunctionType.__new__:
+        return "types.FunctionType"
+    if target is types.MethodType or target is types.MethodType.__new__:
+        return "types.MethodType"
+    if target is map.__new__:
+        return "builtins.map"
+    if target is itertools.accumulate.__new__:
+        return "itertools.accumulate"
+    if target is itertools.groupby.__new__:
+        return "itertools.groupby"
+    if target is itertools.starmap.__new__:
+        return "itertools.starmap"
     if target is operator.attrgetter.__new__:
         return "operator.attrgetter"
     if target is operator.itemgetter.__new__:
         return "operator.itemgetter"
     if target is operator.methodcaller.__new__:
         return "operator.methodcaller"
+    descriptor_name = getattr(target, "__name__", None)
+    owner_module = getattr(descriptor_owner, "__module__", None)
+    owner_qualname = getattr(descriptor_owner, "__qualname__", None)
+    if (
+        descriptor_name is not None
+        and owner_module is not None
+        and owner_qualname is not None
+    ):
+        return f"{owner_module}.{owner_qualname}.{descriptor_name}"
     return _get_target_name_for_check(target)
 
 
@@ -1012,6 +1104,190 @@ def _authorize_callable_result(
     """Authorize a callable selected as another target's runtime result."""
     resolved_name = _get_os_alias_target(_get_resolved_target_name_for_check(result))
     _authorize_target_name(resolved_name, resolved_from, full_key, target_whitelist)
+
+
+def _get_effective_target_invocation(
+    target: Callable[..., Any],
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+) -> Tuple[Callable[..., Any], Tuple[Any, ...], Dict[str, Any]]:
+    """Return the callable and arguments an exact partial will invoke."""
+    while isinstance(target, functools.partial):
+        partial_args = target.args
+        placeholder = getattr(functools, "Placeholder", None)
+        if placeholder is not None and any(arg is placeholder for arg in partial_args):
+            placeholder_count = sum(arg is placeholder for arg in partial_args)
+            if len(args) < placeholder_count:
+                # The partial call will fail before invoking its target.
+                return target, args, kwargs
+            supplied_args = iter(args)
+            partial_args = tuple(
+                next(supplied_args) if arg is placeholder else arg
+                for arg in partial_args
+            )
+            args = partial_args + tuple(supplied_args)
+        else:
+            args = partial_args + args
+        kwargs = {**(target.keywords or {}), **kwargs}
+        target = target.func
+    return target, args, kwargs
+
+
+def _authorize_target_invocation(
+    target: Callable[..., Any],
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+    full_key: str,
+    target_whitelist: NormalizedTargetWhitelist,
+    *,
+    allow_incomplete_partial: bool = False,
+) -> None:
+    """Reject argument-sensitive construction surfaces before invoking them."""
+    if target_whitelist is UNSAFE_ALLOW_ALL_TARGETS:
+        return
+
+    target_name = _get_resolved_target_name_for_check(target)
+    if target_name == "builtins.iter" and len(args) == 2:
+        msg = dedent(
+            """\
+            Target 'builtins.iter' cannot use its two-argument callback form from
+            config because callback execution is deferred beyond instantiate's
+            target authorization. Use one-argument iter(iterable), or perform the
+            callback iteration in trusted Python code. Pass UNSAFE_ALLOW_ALL_TARGETS
+            only to explicitly disable target safety checks."""
+        )
+        raise InstantiationException(_with_full_key(msg, full_key))
+
+    if target_name in _NON_CALLABLE_MOCK_TARGETS:
+        unsafe_parameters = sorted(
+            set(kwargs).difference(_NON_CALLABLE_MOCK_SAFE_PARAMETERS)
+        )
+        if len(args) > 1 or unsafe_parameters:
+            unsafe_details = list(unsafe_parameters)
+            if len(args) > 1:
+                unsafe_details.append(f"{len(args)} positional arguments")
+            joined = ", ".join(unsafe_details)
+            msg = dedent(
+                f"""\
+                Target '{target_name}' cannot configure callable attributes,
+                children, or wrappers from config (unsafe parameters: {joined}).
+                Only one positional spec and the name, spec, and spec_set keyword
+                parameters are allowed. Pass UNSAFE_ALLOW_ALL_TARGETS only to
+                explicitly disable target safety checks."""
+            )
+            raise InstantiationException(_with_full_key(msg, full_key))
+
+    if getattr(target, "__name__", None) in {"__call__", "__new__"}:
+        module = getattr(target, "__module__", None)
+        qualname = getattr(target, "__qualname__", "")
+        owner_qualname, separator, _ = qualname.rpartition(".")
+        if module is not None and separator and "<locals>" not in owner_qualname:
+            try:
+                owner = _locate(f"{module}.{owner_qualname}")
+            except Exception:
+                owner = None
+            if isinstance(owner, type) and issubclass(owner, type):
+                msg = dedent(
+                    f"""\
+                    Target '{target_name}' cannot be used for dynamic class construction
+                    from config. Metaclass constructor methods cannot be authorized with
+                    a target whitelist. Pass UNSAFE_ALLOW_ALL_TARGETS only to explicitly
+                    disable target safety checks."""
+                )
+                raise InstantiationException(_with_full_key(msg, full_key))
+
+    if not isinstance(target, type) or not issubclass(target, type):
+        return
+    if allow_incomplete_partial and len(args) <= 1 and not kwargs:
+        return
+    if len(args) == 1 and not kwargs:
+        return
+    msg = dedent(
+        f"""\
+        Target '{target_name}' cannot be used for dynamic class construction from
+        config. Only one-argument type(obj) introspection is allowed. Pass
+        UNSAFE_ALLOW_ALL_TARGETS only to explicitly disable target safety checks."""
+    )
+    raise InstantiationException(_with_full_key(msg, full_key))
+
+
+class _DeferredTarget(functools.partial):  # type: ignore[type-arg]
+    """Authorize arguments and callable results when a Hydra partial is invoked."""
+
+    _hydra_resolved_from: str
+    _hydra_full_key: str
+    _hydra_target_whitelist: NormalizedTargetWhitelist
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        effective_target, effective_args, effective_kwargs = (
+            _get_effective_target_invocation(self, args, kwargs)
+        )
+        _authorize_target_invocation(
+            effective_target,
+            effective_args,
+            effective_kwargs,
+            self._hydra_full_key,
+            self._hydra_target_whitelist,
+        )
+        discovery_path = _authorize_discovery_path(
+            effective_target,
+            effective_args,
+            effective_kwargs,
+            self._hydra_full_key,
+            self._hydra_target_whitelist,
+        )
+        result = super().__call__(*args, **kwargs)
+        return _mediate_target_result(
+            result,
+            discovery_path or self._hydra_resolved_from,
+            self._hydra_full_key,
+            self._hydra_target_whitelist,
+            discovery_path=discovery_path,
+        )
+
+
+def _mediate_target_result(
+    result: Any,
+    resolved_from: str,
+    full_key: str,
+    target_whitelist: NormalizedTargetWhitelist,
+    *,
+    discovery_path: Optional[str] = None,
+) -> Any:
+    """Authorize callable results and keep deferred partial results mediated."""
+    if target_whitelist is UNSAFE_ALLOW_ALL_TARGETS:
+        return result
+
+    if isinstance(result, functools.partial) and type(result) is not _DeferredTarget:
+        if type(result) is not functools.partial:
+            msg = dedent(
+                """\
+                Callable targets cannot return partial subclasses because overrides
+                can hide their invocation behavior. Return an exact functools.partial
+                or use Hydra's '_partial_: true' support instead."""
+            )
+            raise InstantiationException(_with_full_key(msg, full_key))
+        deferred = _DeferredTarget(
+            result.func,
+            *result.args,
+            **(result.keywords or {}),
+        )
+        deferred.__dict__.update(result.__dict__)
+        deferred._hydra_resolved_from = resolved_from
+        deferred._hydra_full_key = full_key
+        deferred._hydra_target_whitelist = target_whitelist
+        result = deferred
+
+    if callable(result):
+        if discovery_path is not None:
+            _authorize_discovery_result(
+                discovery_path, result, full_key, target_whitelist
+            )
+        else:
+            _authorize_callable_result(
+                result, resolved_from, full_key, target_whitelist
+            )
+    return result
 
 
 def _resolve_target(

--- a/news/3411.bugfix
+++ b/news/3411.bugfix
@@ -1,2 +1,3 @@
 ``instantiate()`` blocks unsafe targets and refuses to whitelist
-config-controlled execution surfaces.
+config-controlled execution surfaces, including aliases, callable wrappers,
+deferred dispatch, and unauthorized callable results.

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -27,6 +27,13 @@ def partial_equal(obj1: Any, obj2: Any) -> bool:
 
     obj1, obj2 = _convert_type(obj1), _convert_type(obj2)
 
+    if isinstance(obj1, partial) and isinstance(obj2, partial):
+        return all(
+            [
+                partial_equal(getattr(obj1, attr), getattr(obj2, attr))
+                for attr in ["func", "args", "keywords"]
+            ]
+        )
     if type(obj1) is not type(obj2):
         return False
     if isinstance(obj1, dict):
@@ -40,14 +47,14 @@ def partial_equal(obj1: Any, obj2: Any) -> bool:
         if len(obj1) != len(obj2):
             return False
         return all(partial_equal(o1, o2) for o1, o2 in zip(obj1, obj2))
-    if not (isinstance(obj1, partial) and isinstance(obj2, partial)):
-        return False
-    return all(
-        [
-            partial_equal(getattr(obj1, attr), getattr(obj2, attr))
-            for attr in ["func", "args", "keywords"]
-        ]
-    )
+    return False
+
+
+def make_attributed_partial() -> partial:
+    result = partial(pow, exp=2)
+    setattr(result, "__name__", "square")
+    setattr(result, "metadata", {"source": "application"})
+    return result
 
 
 class ArgsClass:

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -1,6 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import _threading_local
 import asyncio
+import builtins
+import contextlib
 import copy
+import functools
 import inspect
 import operator
 import os
@@ -11,6 +15,7 @@ from dataclasses import InitVar, dataclass, field
 from functools import partial
 from textwrap import dedent
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from unittest.mock import NonCallableMock
 
 import attr
 from omegaconf import (
@@ -66,6 +71,7 @@ from tests.instantiate import (
     UntypedPassthroughConf,
     User,
     add_values,
+    make_attributed_partial,
     module_function,
     module_function2,
     partial_equal,
@@ -3283,6 +3289,171 @@ def test_blocklist_policy_sections_are_disjoint() -> None:
 @mark.parametrize(
     "target",
     [
+        "builtins.filter",
+        "itertools.dropwhile",
+        "itertools.filterfalse",
+        "itertools.takewhile",
+    ],
+)
+def test_non_result_lazy_callback_targets_are_not_blocklisted(target: str) -> None:
+    assert not _instantiate2._is_blocklisted_target(target)
+
+
+def test_one_argument_iter_target_is_allowed() -> None:
+    result = _instantiate2.instantiate(
+        {"_target_": "builtins.iter", "_args_": [[1, 2]]},
+        _target_whitelist_="builtins.iter",
+    )
+
+    assert list(result) == [1, 2]
+
+
+def test_two_argument_iter_callback_is_blocked_in_legacy_mode() -> None:
+    calls: List[str] = []
+
+    def callback() -> int:
+        calls.append("called")
+        return 1
+
+    cfg = {"_target_": "builtins.iter", "_args_": [callback, 2]}
+    with (
+        warns(UserWarning, match="_target_whitelist_"),
+        raises(InstantiationException, match="two-argument callback form"),
+    ):
+        _instantiate2.instantiate(cfg)
+
+    assert calls == []
+
+
+def test_two_argument_iter_callback_cannot_be_whitelisted() -> None:
+    calls: List[str] = []
+
+    def callback() -> int:
+        calls.append("called")
+        return 1
+
+    cfg = {"_target_": "builtins.iter", "_args_": [callback, 2]}
+    with raises(InstantiationException, match="two-argument callback form"):
+        _instantiate2.instantiate(cfg, _target_whitelist_="builtins.iter")
+
+    assert calls == []
+
+
+def test_partial_call_target_cannot_be_whitelisted() -> None:
+    calls: List[str] = []
+
+    def callback() -> None:
+        calls.append("called")
+
+    cfg = {
+        "_target_": "functools.partial.__call__",
+        "_args_": [partial(callback)],
+    }
+    with raises(
+        InstantiationException,
+        match=r"Target 'functools\.partial\.__call__'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_="functools.partial.__call__")
+
+    assert calls == []
+
+
+def test_property_get_target_cannot_be_whitelisted() -> None:
+    calls: List[str] = []
+
+    class Receiver:
+        pass
+
+    def getter(_: Receiver) -> int:
+        calls.append("called")
+        return 42
+
+    cfg = {
+        "_target_": "builtins.property.__get__",
+        "_args_": [property(getter), Receiver(), Receiver],
+    }
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.property\.__get__'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_="builtins.property.__get__")
+
+    assert calls == []
+
+
+@mark.parametrize(
+    ("target", "canonical_target"),
+    [
+        ("builtins.map.__new__", "builtins.map"),
+        ("builtins.map.__call__", "builtins.map"),
+        ("builtins.classmethod.__new__", "builtins.classmethod"),
+        ("builtins.classmethod.__get__", "builtins.classmethod"),
+        ("builtins.staticmethod.__new__", "builtins.staticmethod"),
+        ("builtins.type.__new__.__call__", "builtins.type.__new__"),
+        ("builtins.type.__call__.__call__", "builtins.type.__call__"),
+        (
+            "concurrent.futures.Executor.map",
+            "concurrent.futures._base.Executor.map",
+        ),
+        (
+            "concurrent.futures.ThreadPoolExecutor.submit",
+            "concurrent.futures.thread.ThreadPoolExecutor.submit",
+        ),
+        (
+            "concurrent.futures.ProcessPoolExecutor.submit",
+            "concurrent.futures.process.ProcessPoolExecutor.submit",
+        ),
+        (
+            "contextlib._GeneratorContextManager.__call__",
+            "contextlib.ContextDecorator.__call__",
+        ),
+        (
+            "contextlib._AsyncGeneratorContextManager.__call__",
+            "contextlib.AsyncContextDecorator.__call__",
+        ),
+        ("functools.reduce.__call__", "_functools.reduce"),
+        ("functools.partialmethod.__call__", "functools.partialmethod"),
+        (
+            "functools.singledispatchmethod.__get__.__call__",
+            "functools.singledispatchmethod.__get__",
+        ),
+        ("types.MethodType.__new__", "types.MethodType"),
+        ("types.FunctionType.__new__", "types.FunctionType"),
+        ("types.LambdaType", "types.FunctionType"),
+        (
+            "builtins.dict.get.__get__",
+            "types.MethodDescriptorType.__get__",
+        ),
+        (
+            "builtins.object.__getattribute__.__get__",
+            "types.WrapperDescriptorType.__get__",
+        ),
+        (
+            "multiprocessing.pool.ThreadPool.apply_async",
+            "multiprocessing.pool.Pool.apply_async",
+        ),
+        (
+            "multiprocessing.pool.ThreadPool.starmap_async",
+            "multiprocessing.pool.Pool.starmap_async",
+        ),
+        ("itertools.accumulate.__new__", "itertools.accumulate"),
+        ("itertools.groupby.__new__", "itertools.groupby"),
+        ("itertools.starmap.__new__", "itertools.starmap"),
+    ],
+)
+def test_callable_dispatch_aliases_are_non_whitelistable(
+    target: str, canonical_target: str
+) -> None:
+    with raises(
+        InstantiationException,
+        match=rf"Target '{re.escape(canonical_target)}'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate({"_target_": target}, _target_whitelist_=target)
+
+
+@mark.parametrize(
+    "target",
+    [
         "operator.call",
         "operator.contains",
         "operator.delitem",
@@ -3799,7 +3970,7 @@ def test_getattr_map_dispatch_chain_is_rejected() -> None:
 
     with raises(
         InstantiationException,
-        match=r"Target 'builtins\.getattr'.*cannot be authorized",
+        match=r"Target 'builtins\.map'.*cannot be authorized",
     ):
         _instantiate2.instantiate(
             cfg,
@@ -3912,7 +4083,7 @@ def test_functools_partial_constructor_rejects_subclass_with_spoofed_func(
 
     with (
         warns(UserWarning),
-        raises(InstantiationException, match="cannot construct partial subclasses"),
+        raises(InstantiationException, match="cannot return partial subclasses"),
     ):
         _instantiate2.instantiate(cfg, _target_whitelist_=target_whitelist)
 
@@ -3960,17 +4131,17 @@ def test_unsafe_allow_all_permits_blocklisted_functools_partial_callable() -> No
     assert factory("1 + 2") == 3
 
 
-def test_direct_functools_partial_cannot_be_deferred_with_target_whitelist() -> None:
+def test_direct_functools_partial_can_be_deferred_with_runtime_authorization() -> None:
     cfg = {"_target_": "functools.partial", "_partial_": True}
 
-    with (
-        warns(UserWarning, match=r"Using '_target_: functools\.partial'"),
-        raises(
-            InstantiationException,
-            match=r"cannot use '_partial_: true'",
-        ),
-    ):
-        _instantiate2.instantiate(cfg, _target_whitelist_="functools.partial")
+    with warns(UserWarning, match=r"Using '_target_: functools\.partial'"):
+        deferred = _instantiate2.instantiate(
+            cfg,
+            _target_whitelist_=["functools.partial", "builtins.pow"],
+        )
+
+    factory = deferred(pow, exp=2)
+    assert factory(3) == 9
 
 
 def test_native_partial_remains_whitelistable() -> None:
@@ -3985,6 +4156,383 @@ def test_native_partial_remains_whitelistable() -> None:
     )
 
     assert factory() == 10
+
+
+def test_callable_result_from_any_target_requires_authorization() -> None:
+    cfg = {
+        "_target_": "builtins.dict.get",
+        "_args_": [{"eval": eval}, "eval"],
+        "_convert_": "all",
+    }
+
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.eval'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_="builtins.dict.get")
+
+
+def test_callable_result_from_any_target_allows_authorized_callable() -> None:
+    cfg = {
+        "_target_": "builtins.dict.get",
+        "_args_": [{"pow": pow}, "pow"],
+        "_convert_": "all",
+    }
+
+    assert (
+        _instantiate2.instantiate(
+            cfg, _target_whitelist_=["builtins.dict.get", "builtins.pow"]
+        )
+        is pow
+    )
+
+
+def test_callable_result_producer_whitelist_does_not_authorize_result() -> None:
+    cfg = {
+        "_target_": "builtins.dict.get",
+        "_args_": [{"remove": os.remove}, "remove"],
+        "_convert_": "all",
+    }
+
+    with raises(
+        InstantiationException,
+        match=r"Target 'os\.remove'.*not in the instantiate target whitelist",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_="builtins.dict.get")
+
+
+def test_native_partial_authorizes_callable_result_when_invoked() -> None:
+    deferred = _instantiate2.instantiate(
+        {
+            "_target_": "builtins.dict.get",
+            "_partial_": True,
+            "_args_": [{"pow": pow, "eval": eval}],
+            "_convert_": "all",
+        },
+        _target_whitelist_=["builtins.dict.get", "builtins.pow"],
+    )
+
+    assert isinstance(deferred, partial)
+    assert deferred("pow") is pow
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.eval'.*cannot be authorized",
+    ):
+        deferred("eval")
+
+
+def test_native_partial_with_runtime_authorization_is_pickleable() -> None:
+    deferred = _instantiate2.instantiate(
+        {"_target_": "builtins.pow", "_partial_": True, "exp": 2},
+        _target_whitelist_="builtins.pow",
+    )
+    restored = pickle.loads(pickle.dumps(deferred))  # nosec B301
+
+    assert isinstance(restored, partial)
+    assert restored.func is pow
+    assert restored(3) == 9
+
+
+def test_native_partial_preserves_unsafe_policy_when_pickled() -> None:
+    deferred = _instantiate2.instantiate(
+        {"_target_": "builtins.dict.get", "_partial_": True},
+        _target_whitelist_=UNSAFE_ALLOW_ALL_TARGETS,
+    )
+    restored = pickle.loads(pickle.dumps(deferred))  # nosec B301
+
+    assert restored({"eval": eval}, "eval") is eval
+
+
+def test_direct_functools_partial_authorizes_result_when_invoked() -> None:
+    cfg = {
+        "_target_": "functools.partial",
+        "_args_": [dict.get, {"pow": pow, "eval": eval}],
+        "_convert_": "all",
+    }
+    with warns(UserWarning, match=r"Using '_target_: functools\.partial'"):
+        factory = _instantiate2.instantiate(
+            cfg,
+            _target_whitelist_=[
+                "functools.partial",
+                "builtins.dict.get",
+                "builtins.pow",
+            ],
+        )
+
+    assert factory("pow") is pow
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.eval'.*cannot be authorized",
+    ):
+        factory("eval")
+
+
+def test_native_partial_mediates_partial_result_when_invoked() -> None:
+    cfg = {
+        "_target_": "functools.partial",
+        "_partial_": True,
+        "_args_": [dict.get, {"pow": pow, "eval": eval}],
+        "_convert_": "all",
+    }
+    with warns(UserWarning, match=r"Using '_target_: functools\.partial'"):
+        outer = _instantiate2.instantiate(
+            cfg,
+            _target_whitelist_=[
+                "functools.partial",
+                "builtins.dict.get",
+                "builtins.pow",
+            ],
+        )
+
+    inner = outer()
+    assert isinstance(inner, partial)
+    assert inner("pow") is pow
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.eval'.*cannot be authorized",
+    ):
+        inner("eval")
+
+
+def test_mediated_partial_result_preserves_attributes() -> None:
+    factory = _instantiate2.instantiate(
+        {"_target_": make_attributed_partial},
+        _target_whitelist_=[
+            "tests.instantiate.make_attributed_partial",
+            "builtins.pow",
+        ],
+    )
+
+    assert factory.__name__ == "square"
+    assert factory.metadata == {"source": "application"}
+    assert factory(3) == 9
+
+
+def test_partial_discovery_target_reauthorizes_runtime_override() -> None:
+    deferred = _instantiate2.instantiate(
+        {
+            "_target_": "hydra.utils.get_object",
+            "_partial_": True,
+            "path": "builtins.pow",
+        },
+        _target_whitelist_=["hydra.utils.get_object", "builtins.pow"],
+    )
+
+    assert deferred() is pow
+    with raises(
+        InstantiationException,
+        match=r"Target 'builtins\.eval'.*cannot be authorized",
+    ):
+        deferred(path="builtins.eval")
+
+
+def test_type_introspection_is_allowed() -> None:
+    assert (
+        _instantiate2.instantiate(
+            {"_target_": "builtins.type", "_args_": [10]},
+            _target_whitelist_=["builtins.type", "builtins.int"],
+        )
+        is int
+    )
+
+
+@mark.parametrize("target", ["builtins.type", "abc.ABCMeta"])
+def test_dynamic_type_construction_is_not_allowed(target: str) -> None:
+    cfg = {
+        "_target_": target,
+        "_args_": ["Selector", [], {"__call__": dict.get}],
+        "_convert_": "all",
+    }
+
+    with raises(
+        InstantiationException,
+        match="cannot be used for dynamic class construction",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_=target)
+
+
+def test_partial_type_reauthorizes_runtime_arguments() -> None:
+    deferred = _instantiate2.instantiate(
+        {"_target_": "builtins.type", "_partial_": True},
+        _target_whitelist_=["builtins.type", "builtins.int"],
+    )
+
+    assert deferred(10) is int
+    with raises(
+        InstantiationException,
+        match="cannot be used for dynamic class construction",
+    ):
+        deferred("Selector", (), {"__call__": dict.get})
+
+
+def test_resolved_partial_target_cannot_bypass_dynamic_type_guard() -> None:
+    initialized_subclasses: List[type] = []
+
+    class Base:
+        def __init_subclass__(cls) -> None:
+            initialized_subclasses.append(cls)
+
+    target = partial(type, "Selector", (Base,), {})
+    with raises(
+        InstantiationException,
+        match="cannot be used for dynamic class construction",
+    ):
+        _instantiate2.instantiate(
+            {"_target_": target},
+            _target_whitelist_="builtins.type",
+        )
+
+    assert initialized_subclasses == []
+
+
+def test_resolved_partial_target_cannot_bypass_mock_parameter_guard() -> None:
+    target = partial(NonCallableMock, wraps={})
+    with raises(
+        InstantiationException,
+        match="cannot configure callable attributes",
+    ):
+        _instantiate2.instantiate(
+            {"_target_": target},
+            _target_whitelist_="unittest.mock.NonCallableMock",
+        )
+
+
+@mark.skipif(
+    not hasattr(functools, "Placeholder"),
+    reason="functools.Placeholder requires Python 3.14",
+)
+def test_resolved_partial_target_substitutes_placeholder_before_guard() -> None:
+    initialized_subclasses: List[type] = []
+
+    class Base:
+        def __init_subclass__(cls) -> None:
+            initialized_subclasses.append(cls)
+
+    placeholder = getattr(functools, "Placeholder")
+    target = partial(type, placeholder, (Base,), {})
+    with raises(
+        InstantiationException,
+        match="cannot be used for dynamic class construction",
+    ):
+        _instantiate2.instantiate(
+            {"_target_": target, "_args_": ["Selector"]},
+            _target_whitelist_="builtins.type",
+        )
+
+    assert initialized_subclasses == []
+
+
+@mark.skipif(
+    not hasattr(functools, "Placeholder"),
+    reason="functools.Placeholder requires Python 3.14",
+)
+def test_resolved_partial_target_preserves_unfilled_placeholder_error() -> None:
+    placeholder = getattr(functools, "Placeholder")
+    target = partial(pow, placeholder, 2)
+
+    with raises(InstantiationException, match="Error in call to target"):
+        _instantiate2.instantiate(
+            {"_target_": target},
+            _target_whitelist_="builtins.pow",
+        )
+
+
+def test_metaclass_constructor_method_is_not_allowed() -> None:
+    with raises(
+        InstantiationException,
+        match="cannot be used for dynamic class construction",
+    ):
+        _instantiate2.instantiate(
+            {"_target_": "abc.ABCMeta.__new__"},
+            _target_whitelist_="abc.ABCMeta.__new__",
+        )
+
+
+@mark.parametrize(
+    "target",
+    ["unittest.mock.NonCallableMock", "unittest.mock.NonCallableMagicMock"],
+)
+def test_non_callable_mock_is_allowed(target: str) -> None:
+    mock = _instantiate2.instantiate(
+        {"_target_": target, "name": "inert"}, _target_whitelist_=target
+    )
+    assert not callable(mock)
+    assert mock._extract_mock_name() == "inert"
+
+
+def test_non_callable_mock_allows_one_positional_spec() -> None:
+    target = "unittest.mock.NonCallableMock"
+    mock = _instantiate2.instantiate(
+        {"_target_": target, "_args_": [[]]}, _target_whitelist_=target
+    )
+    assert not callable(mock)
+
+
+@mark.parametrize(
+    "unsafe_kwargs",
+    [
+        {"child": dict.get},
+        {"child.side_effect": dict.get},
+        {"wraps": {}},
+    ],
+)
+def test_non_callable_mock_cannot_configure_callable_children(
+    unsafe_kwargs: Dict[str, Any],
+) -> None:
+    target = "unittest.mock.NonCallableMock"
+    cfg = {"_target_": target, **unsafe_kwargs}
+    with raises(
+        InstantiationException,
+        match="cannot configure callable attributes",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_=target)
+
+
+def test_non_callable_mock_rejects_positional_wraps() -> None:
+    target = "unittest.mock.NonCallableMock"
+    cfg = {"_target_": target, "_args_": [None, {}]}
+    with raises(
+        InstantiationException,
+        match="cannot configure callable attributes",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_=target)
+
+
+def test_partial_non_callable_mock_reauthorizes_runtime_configuration() -> None:
+    target = "unittest.mock.NonCallableMock"
+    deferred = _instantiate2.instantiate(
+        {"_target_": target, "_partial_": True}, _target_whitelist_=target
+    )
+
+    assert not callable(deferred(name="inert"))
+    with raises(
+        InstantiationException,
+        match="cannot configure callable attributes",
+    ):
+        deferred(**{"child.side_effect": dict.get})
+    with raises(
+        InstantiationException,
+        match="cannot configure callable attributes",
+    ):
+        deferred(None, {})
+
+
+def test_context_decorator_cannot_hide_deferred_callable_selection() -> None:
+    context_manager = getattr(_threading_local, "_patch")(_threading_local.local())
+    wrapper = contextlib.ContextDecorator.__call__(context_manager, dict.get)
+    assert wrapper(vars(builtins), "eval") is eval
+
+    target = "contextlib.ContextDecorator.__call__"
+    cfg = {
+        "_target_": target,
+        "_args_": [context_manager, dict.get],
+        "_convert_": "all",
+    }
+    with raises(
+        InstantiationException,
+        match=r"Target 'contextlib\.ContextDecorator\.__call__'.*cannot be authorized",
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_=target)
 
 
 @mark.parametrize(
@@ -4086,14 +4634,15 @@ def test_discovery_target_applies_legacy_blocklist_to_selected_path() -> None:
         "hydra.utils.get_object",
     ],
 )
-def test_discovery_target_cannot_be_partial_with_target_whitelist(target: str) -> None:
-    cfg = {"_target_": target, "_partial_": True}
+def test_partial_discovery_target_rechecks_runtime_path(target: str) -> None:
+    cfg = {"_target_": target, "_partial_": True, "path": "builtins.int"}
+    deferred = _instantiate2.instantiate(
+        cfg, _target_whitelist_=[target, "builtins.int"]
+    )
 
-    with raises(
-        InstantiationException,
-        match=r"cannot use '_partial_: true'",
-    ):
-        _instantiate2.instantiate(cfg, _target_whitelist_=target)
+    assert deferred() is int
+    with raises(InstantiationException, match="cannot be authorized"):
+        deferred(path="builtins.eval")
 
 
 def test_partial_discovery_target_applies_legacy_blocklist() -> None:
@@ -4103,14 +4652,14 @@ def test_partial_discovery_target_applies_legacy_blocklist() -> None:
         "path": "logging.os.system",
     }
 
-    with (
-        warns(UserWarning, match="_target_whitelist_"),
-        raises(
-            InstantiationException,
-            match=r"Target 'os\.system'.*blocklisted",
-        ),
+    with warns(UserWarning, match="_target_whitelist_"):
+        deferred = _instantiate2.instantiate(cfg)
+
+    with raises(
+        InstantiationException,
+        match=r"Target 'os\.system'.*blocklisted",
     ):
-        _instantiate2.instantiate(cfg)
+        deferred()
 
 
 def test_unsafe_allow_all_permits_partial_discovery_target() -> None:

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -572,20 +572,20 @@ Use the native `_partial_: true` option instead of configuring
 `_target_: functools.partial`. Direct `functools.partial` targets and equivalent
 constructor spellings such as `functools.partial.__new__` are deprecated. When
 used with `_target_whitelist_`, both the partial constructor and its effective
-callable must be authorized. Direct partial targets cannot themselves use
-`_partial_: true` with a real target whitelist because validation would be
-deferred. Equivalent constructor spellings also cannot construct partial
-subclasses while safety checks are active because subclass overrides can hide
-their invocation behavior.
+callable must be authorized. If a direct partial target also uses
+`_partial_: true`, Hydra rechecks its completed callable and any callable result
+when the deferred factory is invoked. Equivalent constructor spellings cannot
+construct partial subclasses while safety checks are active because subclass
+overrides can hide their invocation behavior.
 
 If a config targets `hydra.utils.get_class`, `get_method`,
 `get_static_method`, or `get_object`, whitelist both the discovery helper and
 the dotpath in its `path` argument. Hydra applies the same target policy to the
 selected path and to the canonical identity of a callable result. Discovery
-helpers cannot use `_partial_: true` with a real target whitelist because the
-path could be supplied after authorization has finished. Hydra's `instantiate`
-and `call` functions cannot themselves be authorized as config targets; invoke
-them from trusted Python code.
+helpers may use `_partial_: true`; Hydra checks the effective path on every
+invocation, including a path supplied or replaced at runtime. Hydra's
+`instantiate` and `call` functions cannot themselves be authorized as config
+targets; invoke them from trusted Python code.
 
 Hydra does not authorize `builtins.getattr`, `hasattr`, `setattr`, or `delattr`
 through a real target whitelist. Attribute operations can execute property or

--- a/website/docs/upgrades/1.3_to_1.4/instantiate_target_whitelist.md
+++ b/website/docs/upgrades/1.3_to_1.4/instantiate_target_whitelist.md
@@ -115,13 +115,12 @@ lr: 0.01
 ```
 
 Direct `functools.partial` targets remain deprecated and will become an error in
-Hydra 1.5. They cannot use `_partial_: true` with a real target whitelist
-because construction—and therefore validation of the effective callable—would
-be deferred. The explicit `UNSAFE_ALLOW_ALL_TARGETS` escape hatch permits that
-deferred behavior outside the target whitelist's security guarantee.
-Equivalent constructor spellings cannot construct partial subclasses while
-safety checks are active because subclass overrides can hide their invocation
-behavior.
+Hydra 1.5. If they also use `_partial_: true`, Hydra checks the completed
+partial's effective callable and any callable result when the deferred factory
+is invoked. The explicit `UNSAFE_ALLOW_ALL_TARGETS` escape hatch disables those
+checks. Equivalent constructor spellings cannot construct partial subclasses
+while safety checks are active because subclass overrides can hide their
+invocation behavior.
 
 ## Replace generic operator dispatch
 
@@ -134,11 +133,30 @@ item operation instead of naming it as `_target_`, which can extend a narrow
 whitelist entry into generic selection or dispatch authority. Set `_target_` to
 the intended callable, or call it from trusted Python code, instead.
 
-## Authorize config-selected callable results
+## Authorize callable results
 
-When `hydra.utils.get_class`, `get_method`, `get_static_method`, or
-`get_object` is itself an instantiate target, its `path` value selects another
-object. Authorize both the helper and the selected path from trusted code:
+Hydra applies the active target policy to a callable returned by any target. A
+whitelist entry for a factory does not authorize a class or function returned
+by that factory. Include both targets in the whitelist:
+
+```python
+model_type = instantiate(
+    {
+        "_target_": "my_app.get_model_class",
+        "name": "resnet",
+    },
+    _target_whitelist_=[
+        "my_app.get_model_class",
+        "my_app.models.ResNet",
+    ],
+)
+```
+
+This also applies to Hydra's discovery helpers. When
+`hydra.utils.get_class`, `get_method`, `get_static_method`, or `get_object` is
+itself an instantiate target, its `path` value selects another object.
+
+Authorize both the helper and the selected path from trusted code:
 
 ```python
 obj = instantiate(
@@ -165,13 +183,12 @@ Access or mutate the intended attribute from trusted Python code instead. The
 equivalent `object.__getattribute__` and `type.__getattribute__` dispatch targets
 cannot be authorized either.
 
-Discovery helpers cannot use `_partial_: true` with a real target whitelist.
-The partial could receive its selected path after instantiate's authorization
-has finished. Resolve the value immediately, or expose a narrow trusted Python
-wrapper for the intended operation. The explicit `UNSAFE_ALLOW_ALL_TARGETS`
+Discovery helpers may use `_partial_: true` with a real target whitelist. Hydra
+checks the effective path whenever the deferred factory is invoked, including a
+path supplied or replaced at runtime. The explicit `UNSAFE_ALLOW_ALL_TARGETS`
 escape hatch keeps discovery and attribute access unrestricted. On the legacy
-no-whitelist path, immediately selected callables are still checked against the
-blocklist and ordinary non-callable attribute values remain unchanged.
+no-whitelist path, selected callables are still checked against the blocklist
+and ordinary non-callable attribute values remain unchanged.
 
 Do not configure `hydra.utils.instantiate`, `hydra.utils.call`, or the internal
 `instantiate` function as `_target_`. Hydra refuses to authorize these aliases


### PR DESCRIPTION
Backport the reviewed 1.3 callable-result, deferred-target, dispatcher, wrapper, dynamic-construction, and mock protections to the 1.4 whitelist architecture.

Preserve deferred unsafe-policy semantics across pickle round trips, normalize pre-resolved partial invocations including Python 3.14 placeholders before argument-sensitive authorization, and document invocation-time and callable-result authorization.

The coordinated follow-up rejects deferred two-argument `iter` callbacks while preserving ordinary iteration, and denies direct `functools.partial.__call__` and `builtins.property.__get__` dispatch before side effects can run. The corresponding 1.3 policy update is #3417.

Verification:
- `pytest -q tests/instantiate`: 1036 passed
- `nox -s lint-core-3.11`: passed
- Cross-branch policy collections and the two-argument `iter` guard match the 1.3 implementation.