### PR TITLE
Prepare Hydra 1.3.6 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,6 @@ jobs:
   build-artifacts:
     name: Build distribution artifacts
     runs-on: ubuntu-latest
-    environment: pypi-publish
     steps:
       - uses: actions/checkout@v5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+1.3.6 (2026-08-29)
+==================
+
+### Bug Fixes
+
+- Harden instantiate authorization against unsafe aliases and callable results.
+  ([#3410](https://github.com/facebookresearch/hydra/issues/3410))
+- Apply Hydra's target blocklist to Python logging configuration.
+  ([#3418](https://github.com/facebookresearch/hydra/issues/3418))
+
+
 1.3.5 (2026-08-06)
 ==================
 

--- a/hydra/__init__.py
+++ b/hydra/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 # Source of truth for Hydra's version
-__version__ = "1.3.6.dev0"
+__version__ = "1.3.6"
 from hydra import utils
 from hydra.errors import MissingConfigException
 from hydra.main import main

--- a/news/3410.bugfix
+++ b/news/3410.bugfix
@@ -1,1 +1,0 @@
-Harden instantiate authorization against unsafe aliases and callable results.

--- a/news/3418.bugfix
+++ b/news/3418.bugfix
@@ -1,1 +1,0 @@
-Apply Hydra's target blocklist to Python logging configuration.


### PR DESCRIPTION
Prepares the Hydra 1.3 branch for the hydra-core 1.3.6 patch release.

- Sets the package version to 1.3.6.
- Builds the 1.3.6 NEWS entry from the two security-hardening fragments.
- Consumes the included news fragments.
- Allows artifact-only workflow runs from PR branches while retaining the protected pypi-publish environment on the upload job.

Validation:
- Built the wheel and source distribution locally and in GitHub Actions.
- twine check passed for both local and workflow artifacts.
- Installed the local wheel with dependencies in a clean Python 3.11 environment.
- Verified version metadata, normal instantiate behavior, instantiate blocking, and logging target blocking.
- yamllint passed for the publish workflow.
- Non-publishing workflow run succeeded: https://github.com/hydra-ecosystem/hydra/actions/runs/33255437164

Merging this PR does not publish to PyPI. Publishing remains a separate explicit workflow dispatch with publish=true.