### PR TITLE
Align Optuna sampler configs with Optuna 4.9

### DIFF
--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -34,6 +34,7 @@ class GridSamplerConfig(SamplerConfig):
     _target_: str = "optuna.samplers.GridSampler"
     # search_space will be populated at run time based on hydra.sweeper.params
     _partial_: bool = True
+    seed: Optional[int] = None
 
 
 @dataclass
@@ -52,7 +53,10 @@ class TPESamplerConfig(SamplerConfig):
     n_startup_trials: int = 10
     n_ei_candidates: int = 24
     multivariate: bool = False
+    group: bool = False
     warn_independent_sampling: Optional[bool] = None
+    constant_liar: bool = False
+    constraints_func: Optional[Any] = None
 
 
 @dataclass
@@ -76,12 +80,16 @@ class CmaEsSamplerConfig(SamplerConfig):
 
     x0: Optional[Dict[str, Any]] = None
     sigma0: Optional[float] = None
+    n_startup_trials: int = 1
     independent_sampler: Optional[Any] = None
     warn_independent_sampling: bool = True
     consider_pruned_trials: bool = False
     restart_strategy: Optional[Any] = None
-    inc_popsize: int = 2
+    popsize: Optional[int] = None
+    inc_popsize: int = -1
     use_separable_cma: bool = False
+    with_margin: bool = False
+    lr_adapt: bool = False
     source_trials: Optional[Any] = None
 
 
@@ -96,6 +104,7 @@ class NSGAIISamplerConfig(SamplerConfig):
 
     population_size: int = 50
     mutation_prob: Optional[float] = None
+    crossover: Optional[Any] = None
     crossover_prob: float = 0.9
     swapping_prob: float = 0.5
     constraints_func: Optional[Any] = None

--- a/plugins/hydra_optuna_sweeper/news/3425.feature
+++ b/plugins/hydra_optuna_sweeper/news/3425.feature
@@ -1,0 +1,1 @@
+Align Optuna sampler configs with Optuna 4.9 defaults and options.

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -4,7 +4,6 @@ import sys
 import warnings
 from pathlib import Path
 from typing import Any, List
-from unittest.mock import patch
 
 import optuna
 from hydra import compose, initialize
@@ -78,32 +77,29 @@ def test_sampler_config_defaults(
 
 
 @mark.parametrize(
-    "sampler_name, constructor_path, field_override, expected",
+    "sampler_name, field_override, expected",
     [
-        ("grid", "optuna.samplers.GridSampler", "seed=123", 123),
-        ("tpe", "optuna.samplers.TPESampler", "group=true", True),
-        ("tpe", "optuna.samplers.TPESampler", "constant_liar=true", True),
+        ("grid", "seed=123", 123),
+        ("tpe", "group=true", True),
+        ("tpe", "constant_liar=true", True),
         (
             "tpe",
-            "optuna.samplers.TPESampler",
             "constraints_func=test_constraints",
             "test_constraints",
         ),
-        ("cmaes", "optuna.samplers.CmaEsSampler", "n_startup_trials=7", 7),
-        ("cmaes", "optuna.samplers.CmaEsSampler", "popsize=12", 12),
-        ("cmaes", "optuna.samplers.CmaEsSampler", "with_margin=true", True),
-        ("cmaes", "optuna.samplers.CmaEsSampler", "lr_adapt=true", True),
+        ("cmaes", "n_startup_trials=7", 7),
+        ("cmaes", "popsize=12", 12),
+        ("cmaes", "with_margin=true", True),
+        ("cmaes", "lr_adapt=true", True),
         (
             "nsgaii",
-            "optuna.samplers.NSGAIISampler",
             "crossover=test_crossover",
             "test_crossover",
         ),
     ],
 )
-def test_sampler_normal_override_is_forwarded(
+def test_sampler_normal_override(
     sampler_name: str,
-    constructor_path: str,
     field_override: str,
     expected: Any,
 ) -> None:
@@ -118,20 +114,7 @@ def test_sampler_normal_override_is_forwarded(
             ],
         )
 
-    with patch(
-        f"{constructor_path}.__init__", return_value=None
-    ) as sampler_constructor:
-        sweeper = instantiate(
-            cfg.hydra.sweeper,
-            _execution_whitelist_=(
-                "hydra_plugins.hydra_optuna_sweeper.optuna_sweeper.OptunaSweeper"
-            ),
-            _recursive_=False,
-        )
-        if sampler_name == "grid":
-            sweeper.sweeper.sampler({"x": [0]})
-
-    assert sampler_constructor.call_args.kwargs[field_name] == expected
+    assert cfg.hydra.sweeper.sampler[field_name] == expected
 
 
 def test_default_cmaes_config_has_no_restart_deprecation_warning() -> None:

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -1,10 +1,13 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import os
 import sys
+import warnings
 from pathlib import Path
 from typing import Any, List
+from unittest.mock import patch
 
 import optuna
+from hydra import compose, initialize
 from hydra.core.override_parser.overrides_parser import OverridesParser
 from hydra.core.plugins import Plugins
 from hydra.errors import InstantiationException
@@ -26,7 +29,13 @@ from optuna.distributions import (
 from pytest import mark, raises
 
 from hydra_plugins.hydra_optuna_sweeper import _impl
-from hydra_plugins.hydra_optuna_sweeper.config import MOTPESamplerConfig
+from hydra_plugins.hydra_optuna_sweeper.config import (
+    CmaEsSamplerConfig,
+    GridSamplerConfig,
+    MOTPESamplerConfig,
+    NSGAIISamplerConfig,
+    TPESamplerConfig,
+)
 from hydra_plugins.hydra_optuna_sweeper.optuna_sweeper import OptunaSweeper
 
 chdir_plugin_root()
@@ -45,6 +54,100 @@ def test_discovery() -> None:
     assert OptunaSweeper.__name__ in [
         x.__name__ for x in Plugins.instance().discover(Sweeper)
     ]
+
+
+@mark.parametrize(
+    "config_type, field_name, expected",
+    [
+        (GridSamplerConfig, "seed", None),
+        (TPESamplerConfig, "group", False),
+        (TPESamplerConfig, "constant_liar", False),
+        (TPESamplerConfig, "constraints_func", None),
+        (CmaEsSamplerConfig, "n_startup_trials", 1),
+        (CmaEsSamplerConfig, "popsize", None),
+        (CmaEsSamplerConfig, "with_margin", False),
+        (CmaEsSamplerConfig, "lr_adapt", False),
+        (CmaEsSamplerConfig, "inc_popsize", -1),
+        (NSGAIISamplerConfig, "crossover", None),
+    ],
+)
+def test_sampler_config_defaults(
+    config_type: Any, field_name: str, expected: Any
+) -> None:
+    assert getattr(config_type(), field_name) == expected
+
+
+@mark.parametrize(
+    "sampler_name, constructor_path, field_override, expected",
+    [
+        ("grid", "optuna.samplers.GridSampler", "seed=123", 123),
+        ("tpe", "optuna.samplers.TPESampler", "group=true", True),
+        ("tpe", "optuna.samplers.TPESampler", "constant_liar=true", True),
+        (
+            "tpe",
+            "optuna.samplers.TPESampler",
+            "constraints_func=test_constraints",
+            "test_constraints",
+        ),
+        ("cmaes", "optuna.samplers.CmaEsSampler", "n_startup_trials=7", 7),
+        ("cmaes", "optuna.samplers.CmaEsSampler", "popsize=12", 12),
+        ("cmaes", "optuna.samplers.CmaEsSampler", "with_margin=true", True),
+        ("cmaes", "optuna.samplers.CmaEsSampler", "lr_adapt=true", True),
+        (
+            "nsgaii",
+            "optuna.samplers.NSGAIISampler",
+            "crossover=test_crossover",
+            "test_crossover",
+        ),
+    ],
+)
+def test_sampler_normal_override_is_forwarded(
+    sampler_name: str,
+    constructor_path: str,
+    field_override: str,
+    expected: Any,
+) -> None:
+    field_name = field_override.split("=", maxsplit=1)[0]
+    with initialize(config_path="conf"):
+        cfg = compose(
+            config_name="test_grid",
+            return_hydra_config=True,
+            overrides=[
+                f"hydra/sweeper/sampler={sampler_name}",
+                f"hydra.sweeper.sampler.{field_override}",
+            ],
+        )
+
+    with patch(
+        f"{constructor_path}.__init__", return_value=None
+    ) as sampler_constructor:
+        sweeper = instantiate(
+            cfg.hydra.sweeper,
+            _execution_whitelist_=(
+                "hydra_plugins.hydra_optuna_sweeper.optuna_sweeper.OptunaSweeper"
+            ),
+            _recursive_=False,
+        )
+        if sampler_name == "grid":
+            sweeper.sweeper.sampler({"x": [0]})
+
+    assert sampler_constructor.call_args.kwargs[field_name] == expected
+
+
+def test_default_cmaes_config_has_no_restart_deprecation_warning() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        instantiate(
+            OmegaConf.structured(CmaEsSamplerConfig),
+            _execution_whitelist_="optuna.samplers.*",
+        )
+
+    messages = [str(warning.message).lower() for warning in caught]
+    assert not any(
+        "inc_popsize" in message
+        or ("restart_strategy" in message and "deprecat" in message)
+        for message in messages
+    )
 
 
 def check_distribution(expected: BaseDistribution, actual: BaseDistribution) -> None:
@@ -186,6 +289,7 @@ def test_example_with_grid_sampler(
         "hydra.sweeper.n_jobs=1",
         f"hydra.sweeper.storage={storage}",
         f"hydra.sweeper.study_name={study_name}",
+        "hydra.sweeper.sampler.seed=123",
     ]
     run_optuna_script(cmd)
     returns = OmegaConf.load(f"{tmpdir}/optimization_results.yaml")


### PR DESCRIPTION
## Summary
- expose the requested Optuna 4.9 sampler options in structured configs
- align the CMA-ES inc_popsize default with Optuna 4.9
- add default, override-forwarding, Grid seed, and warning regressions

## Testing
- Optuna Sweeper focused tests: 49 passed
- targeted test_plugins and lint-plugins nox sessions

Fixes #3425