### PR TITLE
Remove redundant setup-xcode step from macOS CI

### DIFF
--- a/.github/actions/macos/action.yml
+++ b/.github/actions/macos/action.yml
@@ -12,9 +12,6 @@ runs:
       path: |-
         ~/miniconda3
         ~/Library/Caches/Homebrew
-  - uses: maxim-lobanov/setup-xcode@v1.6.0
-    with:
-      xcode-version: latest-stable
   - name: Preparing environment - Conda
     run: |-
       if [[ -f ~/miniconda3/LICENSE.txt ]] ; then


### PR DESCRIPTION
Remove the redundant `maxim-lobanov/setup-xcode` step from the shared macOS action. Hydra does not require a specific Xcode version, and the GitHub runner’s default toolchain remains available if needed.

This also removes an unnecessary third-party action from the Actions allowlist.

Validation:
- `.venv/bin/yamllint --strict .github/actions/macos/action.yml`
- Confirmed both `core_tests.yml` and `prepare-release.yml` still use the shared macOS action
- The PR CI macOS matrix exercises the updated action

Closes #3369.