### PR TITLE
Preserve instantiate context for merged subtrees

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -3,12 +3,14 @@
 import copy
 import inspect
 import re
+import weakref
 from contextlib import ExitStack, contextmanager, nullcontext
 from enum import Enum
 from textwrap import dedent
 from typing import (
     Any,
     Callable,
+    ContextManager,
     Dict,
     Iterator,
     List,
@@ -53,6 +55,9 @@ from hydra.errors import InstantiationException
 from hydra.types import ConvertMode
 
 ConfigOverlay = Union[Dict[str, Any], DictConfig]
+DeferredCallContext = Optional[
+    Callable[[_DeferredTarget, Tuple[Any, ...], Dict[str, Any]], ContextManager[None]]
+]
 _INSTANTIATE_OVERRIDE_RESOLVER = "hydra.instantiate_override"
 _INSTANTIATE_OVERRIDE_STORAGE = "_hydra_instantiate_overrides"
 
@@ -82,16 +87,17 @@ def _is_target(x: Any) -> bool:
 
 
 @contextmanager
-def _read_only_config_tree(config: Node) -> Iterator[None]:
-    context_root = config._get_root()
+def _read_only_config_tree(*configs: Node) -> Iterator[None]:
+    context_roots = {id(config._get_root()) for config in configs}
     nodes = []
     pending: List[Node] = []
-    ancestor: Optional[Node] = config
-    while ancestor is not None:
-        # Merged nodes can retain a parent only as interpolation context and may
-        # therefore not be owned by the next ancestor.
-        pending.append(ancestor)
-        ancestor = ancestor._get_parent()
+    for config in configs:
+        ancestor: Optional[Node] = config
+        while ancestor is not None:
+            # Merged nodes can retain a parent only as interpolation context and
+            # may therefore not be owned by the next ancestor.
+            pending.append(ancestor)
+            ancestor = ancestor._get_parent()
     seen = set()
     while pending:
         node = pending.pop()
@@ -119,7 +125,7 @@ def _read_only_config_tree(config: Node) -> Iterator[None]:
     descendant_overrides = ExitStack()
     try:
         for node in nodes:
-            if node is context_root or node._is_flags_root():
+            if id(node) in context_roots or node._is_flags_root():
                 root_overrides.enter_context(flag_override(node, "readonly", True))
             elif node._get_node_flag("readonly") is not True:
                 # Remove local False overrides so the node inherits the guard.
@@ -134,6 +140,31 @@ def _read_only_config_tree(config: Node) -> Iterator[None]:
         # their inherited flag cache against the restored root state.
         root_overrides.close()
         descendant_overrides.close()
+
+
+class _ReadOnlyDeferredTargetContext:
+    def __init__(self, config: Optional[Node]) -> None:
+        self._config_refs: List[weakref.ReferenceType[Node]] = []
+        while config is not None:
+            self._config_refs.append(weakref.ref(config))
+            config = config._get_parent()
+
+    def __call__(
+        self,
+        _deferred: _DeferredTarget,
+        _args: Tuple[Any, ...],
+        _kwargs: Dict[str, Any],
+    ) -> ContextManager[None]:
+        configs = [config for ref in self._config_refs if (config := ref()) is not None]
+        return _read_only_config_tree(*configs) if configs else nullcontext()
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "_ReadOnlyDeferredTargetContext":
+        # A deep-copied deferred target remains in this process and can retain
+        # callable closures that reach the source tree, so preserve its guard.
+        copied = type(self)(None)
+        memo[id(self)] = copied
+        copied._config_refs = self._config_refs.copy()
+        return copied
 
 
 def _warn_legacy_execution_whitelist(target: str) -> None:
@@ -200,6 +231,7 @@ def _call_target(
     kwargs: Dict[str, Any],
     full_key: str,
     execution_whitelist: NormalizedExecutionWhitelist,
+    deferred_call_context: DeferredCallContext,
 ) -> Any:
     """Call target (type) with args and kwargs."""
     try:
@@ -236,6 +268,7 @@ def _call_target(
             deferred._hydra_resolved_from = discovery_path or resolved_target_name
             deferred._hydra_full_key = full_key
             deferred._hydra_execution_whitelist = execution_whitelist
+            deferred._hydra_call_context = deferred_call_context
             return deferred
         result = _target_(*args, **kwargs)
     except Exception as e:
@@ -254,6 +287,7 @@ def _call_target(
         full_key,
         execution_whitelist,
         discovery_path=discovery_path,
+        call_context=deferred_call_context,
     )
 
 
@@ -464,6 +498,11 @@ def instantiate(
             if source_config_is_omegaconf
             else nullcontext()
         )
+        deferred_call_context = (
+            _ReadOnlyDeferredTargetContext(config)
+            if source_config_is_omegaconf
+            else None
+        )
         # No private copy was made for OmegaConf input. Keep the entire
         # instantiation read-only, including target constructors.
         with guard:
@@ -473,6 +512,7 @@ def instantiate(
                 overrides=kwargs,
                 is_root=True,
                 execution_whitelist=execution_whitelist,
+                deferred_call_context=deferred_call_context,
             )
     elif OmegaConf.is_sequence(config):
         _recursive_ = kwargs.pop(_Keys.RECURSIVE, True)
@@ -491,6 +531,11 @@ def instantiate(
             if source_config_is_omegaconf
             else nullcontext()
         )
+        deferred_call_context = (
+            _ReadOnlyDeferredTargetContext(config)
+            if source_config_is_omegaconf
+            else None
+        )
         with guard:
             return instantiate_node(
                 config,
@@ -499,6 +544,7 @@ def instantiate(
                 convert=_convert_,
                 partial=_partial_,
                 execution_whitelist=execution_whitelist,
+                deferred_call_context=deferred_call_context,
             )
     else:
         raise InstantiationException(
@@ -628,6 +674,7 @@ def _instantiate_override(
     convert: Union[str, ConvertMode],
     recursive: bool,
     execution_whitelist: NormalizedExecutionWhitelist,
+    deferred_call_context: DeferredCallContext,
 ) -> Any:
     if is_structured_config(value):
         return value
@@ -647,6 +694,7 @@ def _instantiate_override(
             convert=convert,
             recursive=recursive,
             execution_whitelist=execution_whitelist,
+            deferred_call_context=deferred_call_context,
         )
 
     if isinstance(value, (list, tuple)):
@@ -656,6 +704,7 @@ def _instantiate_override(
                 convert=convert,
                 recursive=recursive,
                 execution_whitelist=execution_whitelist,
+                deferred_call_context=deferred_call_context,
             )
             for item in value
         ]
@@ -669,6 +718,7 @@ def _instantiate_override(
             convert=convert,
             recursive=recursive,
             execution_whitelist=execution_whitelist,
+            deferred_call_context=deferred_call_context,
         )
     return value
 
@@ -897,6 +947,7 @@ def _instantiate_effective_value(
     convert: Union[str, ConvertMode],
     recursive: bool,
     execution_whitelist: NormalizedExecutionWhitelist,
+    deferred_call_context: DeferredCallContext,
 ) -> Any:
     if overrides is not None and key in overrides:
         override = overrides[key]
@@ -915,6 +966,7 @@ def _instantiate_effective_value(
                         convert=convert,
                         recursive=recursive,
                         execution_whitelist=execution_whitelist,
+                        deferred_call_context=deferred_call_context,
                     )
                 return value
         return _instantiate_override(
@@ -922,6 +974,7 @@ def _instantiate_effective_value(
             convert=convert,
             recursive=recursive,
             execution_whitelist=execution_whitelist,
+            deferred_call_context=deferred_call_context,
         )
 
     value = node[key]
@@ -931,6 +984,7 @@ def _instantiate_effective_value(
             convert=convert,
             recursive=recursive,
             execution_whitelist=execution_whitelist,
+            deferred_call_context=deferred_call_context,
         )
     return value
 
@@ -944,6 +998,7 @@ def instantiate_node(
     partial: bool = False,
     is_root: bool = False,
     execution_whitelist: NormalizedExecutionWhitelist = None,
+    deferred_call_context: DeferredCallContext = None,
 ) -> Any:
     # Return None if config is None
     if node is None or (
@@ -995,6 +1050,7 @@ def instantiate_node(
                 convert=convert,
                 recursive=recursive,
                 execution_whitelist=execution_whitelist,
+                deferred_call_context=deferred_call_context,
             )
             for item in node._iter_ex(resolve=True)
         ]
@@ -1033,11 +1089,18 @@ def instantiate_node(
                         convert=convert,
                         recursive=recursive,
                         execution_whitelist=execution_whitelist,
+                        deferred_call_context=deferred_call_context,
                     )
                     kwargs[key] = _convert_node(value, convert)
 
             return _call_target(
-                _target_, partial, args, kwargs, full_key, execution_whitelist
+                _target_,
+                partial,
+                args,
+                kwargs,
+                full_key,
+                execution_whitelist,
+                deferred_call_context,
             )
         else:
             object_type = node._metadata.object_type
@@ -1065,6 +1128,7 @@ def instantiate_node(
                         convert=convert,
                         recursive=recursive,
                         execution_whitelist=execution_whitelist,
+                        deferred_call_context=deferred_call_context,
                     )
                 return dict_items
             else:
@@ -1082,6 +1146,7 @@ def instantiate_node(
                             convert=convert,
                             recursive=recursive,
                             execution_whitelist=execution_whitelist,
+                            deferred_call_context=deferred_call_context,
                         )
                     )
                 cfg._set_parent(node)

--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -3,11 +3,32 @@
 import copy
 import inspect
 import re
+from contextlib import ExitStack, contextmanager, nullcontext
 from enum import Enum
 from textwrap import dedent
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
 
-from omegaconf import AnyNode, DictConfig, Node, OmegaConf, SCMode
+from omegaconf import (
+    AnyNode,
+    Container,
+    DictConfig,
+    Node,
+    OmegaConf,
+    SCMode,
+    UnionNode,
+    flag_override,
+)
 from omegaconf._utils import is_structured_config
 from omegaconf.errors import InterpolationResolutionError
 
@@ -58,6 +79,61 @@ def _is_target(x: Any) -> bool:
     if OmegaConf.is_dict(x):
         return "_target_" in x
     return False
+
+
+@contextmanager
+def _read_only_config_tree(config: Node) -> Iterator[None]:
+    context_root = config._get_root()
+    nodes = []
+    pending: List[Node] = []
+    ancestor: Optional[Node] = config
+    while ancestor is not None:
+        # Merged nodes can retain a parent only as interpolation context and may
+        # therefore not be owned by the next ancestor.
+        pending.append(ancestor)
+        ancestor = ancestor._get_parent()
+    seen = set()
+    while pending:
+        node = pending.pop()
+        if id(node) in seen:
+            continue
+        seen.add(id(node))
+
+        if isinstance(node, Container):
+            nodes.append(node)
+            keys: Sequence[Any]
+            if isinstance(node, DictConfig):
+                keys = list(node.keys())
+            else:
+                keys = range(len(cast(Sequence[Any], node)))
+            for key in keys:
+                child = node._get_node(key)
+                if isinstance(child, Node):
+                    pending.append(child)
+        elif isinstance(node, UnionNode):
+            child = node._value()
+            if isinstance(child, Node):
+                pending.append(child)
+
+    root_overrides = ExitStack()
+    descendant_overrides = ExitStack()
+    try:
+        for node in nodes:
+            if node is context_root or node._is_flags_root():
+                root_overrides.enter_context(flag_override(node, "readonly", True))
+            elif node._get_node_flag("readonly") is not True:
+                # Remove local False overrides so the node inherits the guard.
+                # Leaving descendants without local True flags also preserves
+                # read_write(parent)'s normal subtree behavior.
+                descendant_overrides.enter_context(
+                    flag_override(node, "readonly", None)
+                )
+        yield
+    finally:
+        # Restore roots before descendants so context-parented nodes invalidate
+        # their inherited flag cache against the restored root state.
+        root_overrides.close()
+        descendant_overrides.close()
 
 
 def _warn_legacy_execution_whitelist(target: str) -> None:
@@ -348,6 +424,7 @@ def instantiate(
         return None
 
     execution_whitelist = _resolve_execution_whitelist(_execution_whitelist_)
+    source_config_is_omegaconf = OmegaConf.is_config(config)
 
     for index, value in enumerate(args):
         _validate_callsite_override(value, (_Keys.ARGS, index))
@@ -375,13 +452,28 @@ def instantiate(
             config = _copy_config_with_override_interpolations(
                 config, resolution_overrides
             )
-        return instantiate_node(
-            config,
-            *args,
-            overrides=kwargs,
-            is_root=True,
-            execution_whitelist=execution_whitelist,
+            return instantiate_node(
+                config,
+                *args,
+                overrides=kwargs,
+                is_root=True,
+                execution_whitelist=execution_whitelist,
+            )
+        guard = (
+            _read_only_config_tree(config)
+            if source_config_is_omegaconf
+            else nullcontext()
         )
+        # No private copy was made for OmegaConf input. Keep the entire
+        # instantiation read-only, including target constructors.
+        with guard:
+            return instantiate_node(
+                config,
+                *args,
+                overrides=kwargs,
+                is_root=True,
+                execution_whitelist=execution_whitelist,
+            )
     elif OmegaConf.is_sequence(config):
         _recursive_ = kwargs.pop(_Keys.RECURSIVE, True)
         _convert_ = kwargs.pop(_Keys.CONVERT, ConvertMode.NONE)
@@ -394,14 +486,20 @@ def instantiate(
                 f"top-level {sequence_type} instantiation"
             )
 
-        return instantiate_node(
-            config,
-            *args,
-            recursive=_recursive_,
-            convert=_convert_,
-            partial=_partial_,
-            execution_whitelist=execution_whitelist,
+        guard = (
+            _read_only_config_tree(config)
+            if source_config_is_omegaconf
+            else nullcontext()
         )
+        with guard:
+            return instantiate_node(
+                config,
+                *args,
+                recursive=_recursive_,
+                convert=_convert_,
+                partial=_partial_,
+                execution_whitelist=execution_whitelist,
+            )
     else:
         raise InstantiationException(
             dedent(f"""\
@@ -744,13 +842,24 @@ def _copy_config_with_override_interpolations(
     path = []
     current: Any = config
     while current._get_parent() is not None:
-        path.append(current._key())
-        current = current._get_parent()
+        parent = current._get_parent()
+        key = current._key()
+        path.append((key, current, _get_override_child(parent, key) is current))
+        current = parent
 
     copied_root = copy.deepcopy(current)
     copied_config = copied_root
-    for key in reversed(path):
+    for key, source_config, parent_owns_source in reversed(path):
         copied_config = _get_override_child(copied_config, key)
+        # Merged nodes can retain a parent only as interpolation context.
+        if not parent_owns_source:
+            # This tree is a private copy, so it is safe to mutate even when it
+            # retains read-only flags from the source configuration.
+            merge_source = copy.deepcopy(source_config)
+            # Isolate the private source from flags inherited through its
+            # original parent while preserving that parent for interpolation.
+            merge_source._set_flags_root(True)
+            copied_config._merge_with(merge_source, _allow_readonly_target=True)
 
     if copied_config._is_none():
         ref_type = copied_config._metadata.ref_type

--- a/hydra/_internal/target_policy.py
+++ b/hydra/_internal/target_policy.py
@@ -1,13 +1,25 @@
 # SPDX-FileCopyrightText: Contributors to Hydra
 # SPDX-License-Identifier: MIT
 
+import copy
 import functools
 import itertools
 import operator
 import types
+from contextlib import nullcontext
 from contextvars import ContextVar
 from textwrap import dedent
-from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Optional,
+    Sequence,
+    SupportsIndex,
+    Tuple,
+    Union,
+    cast,
+)
 
 from hydra._internal._locate import _locate
 from hydra.errors import InstantiationException
@@ -1058,33 +1070,72 @@ class _DeferredTarget(functools.partial):  # type: ignore[type-arg]
     _hydra_resolved_from: str
     _hydra_full_key: str
     _hydra_execution_whitelist: NormalizedExecutionWhitelist
+    _hydra_call_context: Optional[
+        Callable[["_DeferredTarget", Tuple[Any, ...], Dict[str, Any]], Any]
+    ] = None
+
+    def __copy__(self) -> "_DeferredTarget":
+        copied = type(self)(
+            cast(Callable[..., Any], self.func),
+            *self.args,
+            **(self.keywords or {}),
+        )
+        copied.__dict__.update(self.__dict__)
+        return copied
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "_DeferredTarget":
+        copied = type(self)(cast(Callable[..., Any], self.func))
+        memo[id(self)] = copied
+        setstate = cast(Callable[[Any], None], getattr(copied, "__setstate__"))
+        setstate(
+            (
+                copy.deepcopy(self.func, memo),
+                copy.deepcopy(self.args, memo),
+                copy.deepcopy(self.keywords, memo),
+                copy.deepcopy(self.__dict__, memo),
+            )
+        )
+        return copied
+
+    def __reduce__(self) -> Union[str, Tuple[Any, ...]]:
+        raise TypeError("Hydra _partial_ factories cannot be pickled before invocation")
+
+    def __reduce_ex__(self, _protocol: SupportsIndex, /) -> Union[str, Tuple[Any, ...]]:
+        return self.__reduce__()
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        effective_target, effective_args, effective_kwargs = (
-            _get_effective_target_invocation(self, args, kwargs)
+        context = (
+            self._hydra_call_context(self, args, kwargs)
+            if self._hydra_call_context is not None
+            else nullcontext()
         )
-        _authorize_target_invocation(
-            effective_target,
-            effective_args,
-            effective_kwargs,
-            self._hydra_full_key,
-            self._hydra_execution_whitelist,
-        )
-        discovery_path = _authorize_discovery_path(
-            effective_target,
-            effective_args,
-            effective_kwargs,
-            self._hydra_full_key,
-            self._hydra_execution_whitelist,
-        )
-        result = super().__call__(*args, **kwargs)
-        return _mediate_target_result(
-            result,
-            discovery_path or self._hydra_resolved_from,
-            self._hydra_full_key,
-            self._hydra_execution_whitelist,
-            discovery_path=discovery_path,
-        )
+        with context:
+            effective_target, effective_args, effective_kwargs = (
+                _get_effective_target_invocation(self, args, kwargs)
+            )
+            _authorize_target_invocation(
+                effective_target,
+                effective_args,
+                effective_kwargs,
+                self._hydra_full_key,
+                self._hydra_execution_whitelist,
+            )
+            discovery_path = _authorize_discovery_path(
+                effective_target,
+                effective_args,
+                effective_kwargs,
+                self._hydra_full_key,
+                self._hydra_execution_whitelist,
+            )
+            result = super().__call__(*args, **kwargs)
+            return _mediate_target_result(
+                result,
+                discovery_path or self._hydra_resolved_from,
+                self._hydra_full_key,
+                self._hydra_execution_whitelist,
+                discovery_path=discovery_path,
+                call_context=self._hydra_call_context,
+            )
 
 
 def _mediate_target_result(
@@ -1094,9 +1145,18 @@ def _mediate_target_result(
     execution_whitelist: NormalizedExecutionWhitelist,
     *,
     discovery_path: Optional[str] = None,
+    call_context: Optional[
+        Callable[[_DeferredTarget, Tuple[Any, ...], Dict[str, Any]], Any]
+    ] = None,
 ) -> Any:
     """Authorize callable results and keep deferred partial results mediated."""
-    if execution_whitelist is UNSAFE_DISABLE_EXECUTION_CHECKS:
+    guard_returned_partial = (
+        call_context is not None and type(result) is functools.partial
+    )
+    if (
+        execution_whitelist is UNSAFE_DISABLE_EXECUTION_CHECKS
+        and not guard_returned_partial
+    ):
         return result
 
     if isinstance(result, functools.partial) and type(result) is not _DeferredTarget:
@@ -1117,6 +1177,7 @@ def _mediate_target_result(
         deferred._hydra_resolved_from = resolved_from
         deferred._hydra_full_key = full_key
         deferred._hydra_execution_whitelist = execution_whitelist
+        deferred._hydra_call_context = call_context
         result = deferred
 
     if callable(result):

--- a/news/3436.api_change
+++ b/news/3436.api_change
@@ -1,1 +1,2 @@
 Make source configs temporarily read-only during copy-free instantiation.
+Reject pickling Hydra `_partial_` factories before invocation.

--- a/news/3436.api_change
+++ b/news/3436.api_change
@@ -1,0 +1,1 @@
+Make source configs temporarily read-only during copy-free instantiation.

--- a/news/3436.bugfix
+++ b/news/3436.bugfix
@@ -1,0 +1,1 @@
+Preserve merged ancestor values when instantiating context-parented subtrees.

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -5,12 +5,14 @@ import builtins
 import contextlib
 import copy
 import functools
+import gc
 import inspect
 import operator
 import os
 import pickle
 import re
 import warnings
+import weakref
 from dataclasses import InitVar, dataclass, field
 from functools import partial
 from textwrap import dedent
@@ -162,6 +164,10 @@ class NestedConfigMutationProbe:
         self.payload = payload
         with read_write(payload):
             payload.child.value = 20
+
+
+def make_config_mutation_partial(payload: DictConfig) -> partial:
+    return partial(ConfigMutationProbe, payload)
 
 
 @fixture(
@@ -1121,6 +1127,277 @@ def test_no_override_config_read_write_unlocks_nested_nodes(
     assert not OmegaConf.is_readonly(cfg.payload.child)
 
 
+def test_no_override_partial_config_is_readonly_when_invoked(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "_target_": "tests.instantiate.test_instantiate.ConfigMutationProbe",
+            "_partial_": True,
+            "_recursive_": False,
+            "payload": {"value": 10},
+        }
+    )
+    OmegaConf.set_readonly(cfg.payload, False)
+
+    factory = instantiate_func(cfg)
+
+    assert not OmegaConf.is_readonly(cfg.payload)
+    result = factory()
+    assert result.readonly
+    assert result.mutation_blocked
+    assert cfg.payload.value == 10
+    assert cfg.payload._get_node_flag("readonly") is False
+
+
+def test_partial_runtime_override_of_source_config_is_readonly(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "_target_": "tests.instantiate.test_instantiate.ConfigMutationProbe",
+            "_partial_": True,
+            "_recursive_": False,
+            "payload": {"value": 10},
+        }
+    )
+
+    factory = instantiate_func(cfg)
+    result = factory(payload=cfg.payload)
+
+    assert result.readonly
+    assert result.mutation_blocked
+    assert cfg.payload.value == 10
+    assert not OmegaConf.is_readonly(cfg.payload)
+
+
+def test_partial_runtime_override_of_independent_config_remains_writable(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "_target_": "tests.instantiate.test_instantiate.ConfigMutationProbe",
+            "_partial_": True,
+            "_recursive_": False,
+            "payload": {"value": 10},
+        }
+    )
+    independent = OmegaConf.create({"value": 30})
+
+    factory = instantiate_func(cfg)
+    result = factory(payload=independent)
+
+    assert not result.readonly
+    assert not result.mutation_blocked
+    assert independent.value == 20
+    assert cfg.payload.value == 10
+
+
+def test_partial_callable_closure_source_config_is_readonly(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "shared": {"value": 10},
+            "factory": {"_target_": None, "_partial_": True},
+        },
+        flags={"allow_objects": True},
+    )
+
+    def target() -> ConfigMutationProbe:
+        return ConfigMutationProbe(cfg.shared)
+
+    cfg.factory._target_ = target
+    factory = instantiate_func(
+        cfg.factory, _execution_whitelist_=UNSAFE_DISABLE_EXECUTION_CHECKS
+    )
+    result = factory()
+
+    assert result.readonly
+    assert result.mutation_blocked
+    assert cfg.shared.value == 10
+    assert not OmegaConf.is_readonly(cfg.shared)
+
+
+@mark.parametrize("copier", [copy.copy, copy.deepcopy], ids=["copy", "deepcopy"])
+def test_copied_partial_callable_closure_source_config_is_readonly(
+    instantiate_func: Any, copier: Callable[[Any], Any]
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "shared": {"value": 10},
+            "factory": {"_target_": None, "_partial_": True},
+        },
+        flags={"allow_objects": True},
+    )
+
+    def target() -> ConfigMutationProbe:
+        return ConfigMutationProbe(cfg.shared)
+
+    cfg.factory._target_ = target
+    factory = instantiate_func(
+        cfg.factory, _execution_whitelist_=UNSAFE_DISABLE_EXECUTION_CHECKS
+    )
+    copied_factory = copier(factory)
+    result = copied_factory()
+
+    assert result.readonly
+    assert result.mutation_blocked
+    assert cfg.shared.value == 10
+    assert not OmegaConf.is_readonly(cfg.shared)
+
+
+def test_partial_context_ancestor_remains_guarded_after_merged_entry_expires(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "shared": {"value": 10},
+            "factory": {
+                "base": "???",
+                "node": {"_target_": None, "_partial_": True},
+            },
+        },
+        flags={"allow_objects": True},
+    )
+
+    def target() -> ConfigMutationProbe:
+        return ConfigMutationProbe(cfg.shared)
+
+    cfg.factory.node._target_ = target
+    merged = OmegaConf.merge(cfg.factory, {"base": 20})
+    source_ref = weakref.ref(merged.node)
+    factory = instantiate_func(
+        merged.node, _execution_whitelist_=UNSAFE_DISABLE_EXECUTION_CHECKS
+    )
+
+    del merged
+    gc.collect()
+    assert source_ref() is None
+    result = factory()
+
+    assert result.readonly
+    assert result.mutation_blocked
+    assert cfg.shared.value == 10
+    assert not OmegaConf.is_readonly(cfg.shared)
+
+
+def test_no_override_nested_partial_config_is_readonly_when_invoked(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "factory": {
+                "_target_": "tests.instantiate.test_instantiate.ConfigMutationProbe",
+                "_partial_": True,
+                "_recursive_": False,
+                "payload": {"value": 10},
+            },
+        }
+    )
+
+    result = instantiate_func(cfg)
+    probe = result.kwargs["factory"]()
+
+    assert probe.readonly
+    assert probe.mutation_blocked
+    assert cfg.factory.payload.value == 10
+    assert not OmegaConf.is_readonly(cfg.factory.payload)
+
+
+def test_partial_target_bound_config_is_readonly_when_invoked(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "shared": {"value": 10},
+            "factory": {"_target_": None, "_partial_": True},
+        },
+        flags={"allow_objects": True},
+    )
+    cfg.factory._target_ = partial(ConfigMutationProbe, cfg.shared)
+
+    factory = instantiate_func(
+        cfg.factory,
+        _execution_whitelist_="tests.instantiate.test_instantiate.ConfigMutationProbe",
+    )
+    assert factory.func is ConfigMutationProbe
+    assert factory.args == (cfg.shared,)
+    assert not OmegaConf.is_readonly(cfg.shared)
+
+    result = factory()
+
+    assert result.readonly
+    assert result.mutation_blocked
+    assert cfg.shared.value == 10
+    assert not OmegaConf.is_readonly(cfg.shared)
+
+
+def test_no_override_partial_config_read_write_unlocks_nested_nodes(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "_target_": "tests.instantiate.test_instantiate.NestedConfigMutationProbe",
+            "_partial_": True,
+            "_recursive_": False,
+            "payload": {"child": {"value": 10}},
+        }
+    )
+
+    factory = instantiate_func(cfg)
+    result = factory()
+
+    assert result.payload is cfg.payload
+    assert cfg.payload.child.value == 20
+    assert not OmegaConf.is_readonly(cfg.payload)
+    assert not OmegaConf.is_readonly(cfg.payload.child)
+
+
+def test_no_override_partial_config_readonly_is_restored_after_failure(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "_target_": "tests.instantiate.test_instantiate.ConfigMutationProbe",
+            "_partial_": True,
+            "_recursive_": False,
+            "payload": {"value": 10},
+            "fail": True,
+        }
+    )
+
+    factory = instantiate_func(cfg)
+    with raises(RuntimeError, match="expected failure"):
+        factory()
+
+    assert cfg.payload.value == 10
+    assert not OmegaConf.is_readonly(cfg.payload)
+
+
+def test_returned_partial_preserves_readonly_guard_when_checks_are_disabled(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "_target_": "tests.instantiate.test_instantiate.make_config_mutation_partial",
+            "_recursive_": False,
+            "payload": {"value": 10},
+        }
+    )
+
+    factory = instantiate_func(
+        cfg, _execution_whitelist_=UNSAFE_DISABLE_EXECUTION_CHECKS
+    )
+    result = factory()
+
+    assert result.readonly
+    assert result.mutation_blocked
+    assert cfg.payload.value == 10
+    assert not OmegaConf.is_readonly(cfg.payload)
+
+
 def test_no_override_interpolated_config_is_readonly_during_instantiation(
     instantiate_func: Any,
 ) -> None:
@@ -1199,6 +1476,46 @@ def test_private_config_copy_remains_writable(instantiate_func: Any) -> None:
     )
 
     result = instantiate_func(cfg, _convert_="none")
+
+    assert not result.readonly
+    assert not result.mutation_blocked
+    assert result.payload.value == 20
+    assert cfg.payload.value == 10
+
+
+def test_native_partial_config_remains_writable_when_invoked(
+    instantiate_func: Any,
+) -> None:
+    cfg = {
+        "_target_": "tests.instantiate.test_instantiate.ConfigMutationProbe",
+        "_partial_": True,
+        "_recursive_": False,
+        "payload": {"value": 10},
+    }
+
+    factory = instantiate_func(cfg)
+    result = factory()
+
+    assert not result.readonly
+    assert not result.mutation_blocked
+    assert result.payload.value == 20
+    assert cfg["payload"]["value"] == 10
+
+
+def test_private_partial_config_copy_remains_writable_when_invoked(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "_target_": "tests.instantiate.test_instantiate.ConfigMutationProbe",
+            "_partial_": True,
+            "_recursive_": False,
+            "payload": {"value": 10},
+        }
+    )
+
+    factory = instantiate_func(cfg, _convert_="none")
+    result = factory()
 
     assert not result.readonly
     assert not result.mutation_blocked
@@ -4502,26 +4819,47 @@ def test_native_partial_authorizes_callable_result_when_invoked() -> None:
         deferred("eval")
 
 
-def test_native_partial_with_runtime_authorization_is_pickleable() -> None:
+@mark.parametrize(
+    "execution_whitelist",
+    ["builtins.pow", UNSAFE_DISABLE_EXECUTION_CHECKS],
+)
+def test_native_partial_cannot_be_pickled_before_invocation(
+    execution_whitelist: Any,
+) -> None:
     deferred = _instantiate2.instantiate(
-        {"_target_": "builtins.pow", "_partial_": True, "exp": 2},
-        _execution_whitelist_="builtins.pow",
+        OmegaConf.create({"_target_": "builtins.pow", "_partial_": True, "exp": 2}),
+        _execution_whitelist_=execution_whitelist,
     )
-    restored = pickle.loads(pickle.dumps(deferred))  # nosec B301
 
-    assert isinstance(restored, partial)
-    assert restored.func is pow
-    assert restored(3) == 9
+    with raises(
+        TypeError,
+        match="Hydra _partial_ factories cannot be pickled before invocation",
+    ):
+        pickle.dumps(deferred)
 
 
-def test_native_partial_preserves_unsafe_policy_when_pickled() -> None:
-    deferred = _instantiate2.instantiate(
-        {"_target_": "builtins.dict.get", "_partial_": True},
-        _execution_whitelist_=UNSAFE_DISABLE_EXECUTION_CHECKS,
+def test_attached_partial_does_not_retain_unrelated_ancestors() -> None:
+    cfg = OmegaConf.create(
+        {
+            "unrelated": {"value": 10},
+            "factory": {
+                "_target_": "builtins.pow",
+                "_partial_": True,
+                "base": 3,
+            },
+        },
+        flags={"allow_objects": True},
     )
-    restored = pickle.loads(pickle.dumps(deferred))  # nosec B301
 
-    assert restored({"eval": eval}, "eval") is eval
+    factory = _instantiate2.instantiate(
+        cfg.factory, _execution_whitelist_="builtins.pow"
+    )
+    source_ref = weakref.ref(cfg)
+    del cfg
+    gc.collect()
+
+    assert source_ref() is None
+    assert factory(exp=2) == 9
 
 
 def test_direct_functools_partial_authorizes_result_when_invoked() -> None:

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -26,8 +26,9 @@ from omegaconf import (
     MissingMandatoryValue,
     OmegaConf,
     TupleConfig,
+    read_write,
 )
-from omegaconf.errors import ValidationError
+from omegaconf.errors import ReadonlyConfigError, ValidationError
 from pytest import fixture, mark, param, raises, warns
 
 from hydra._internal import target_policy
@@ -140,6 +141,27 @@ class ItemOperationProbe:
     def __contains__(self, item: object) -> bool:
         type(self).membership_checked = True
         return False
+
+
+class ConfigMutationProbe:
+    def __init__(self, payload: DictConfig, fail: bool = False) -> None:
+        self.payload = payload
+        self.readonly = OmegaConf.is_readonly(payload)
+        try:
+            payload.value = 20
+        except ReadonlyConfigError:
+            self.mutation_blocked = True
+        else:
+            self.mutation_blocked = False
+        if fail:
+            raise RuntimeError("expected failure")
+
+
+class NestedConfigMutationProbe:
+    def __init__(self, payload: DictConfig) -> None:
+        self.payload = payload
+        with read_write(payload):
+            payload.child.value = 20
 
 
 @fixture(
@@ -550,6 +572,85 @@ def test_callsite_override_is_visible_through_absolute_interpolation(
 
     assert result.kwargs == {"base": 20, "derived": 20}
     assert config.node.base == 10
+
+
+def test_callsite_override_preserves_context_only_merged_ancestor(
+    instantiate_func: Any,
+) -> None:
+    config = OmegaConf.create(
+        {
+            "factory": {
+                "base": "???",
+                "target": {
+                    "_target_": "tests.instantiate.ArgsClass",
+                    "value": "${..base}",
+                },
+            }
+        }
+    )
+    merged = OmegaConf.merge(config.factory, {"base": 10})
+
+    assert merged._get_parent() is config
+    assert config.factory is not merged
+    assert merged.target.value == 10
+
+    result = instantiate_func(merged.target, extra=20)
+
+    assert result.kwargs == {"value": 10, "extra": 20}
+    assert OmegaConf.is_missing(config.factory, "base")
+
+
+def test_callsite_override_preserves_readonly_context_only_merged_ancestor(
+    instantiate_func: Any,
+) -> None:
+    config = OmegaConf.create(
+        {
+            "factory": {
+                "base": "???",
+                "target": {
+                    "_target_": "tests.instantiate.ArgsClass",
+                    "value": "${..base}",
+                },
+            }
+        }
+    )
+    OmegaConf.set_readonly(config, True)
+    merged = OmegaConf.merge(config.factory, {"base": 10})
+
+    result = instantiate_func(merged.target, extra=20)
+
+    assert result.kwargs == {"value": 10, "extra": 20}
+    assert OmegaConf.is_missing(config.factory, "base")
+    assert OmegaConf.is_readonly(config)
+
+
+def test_callsite_override_preserves_nested_readonly_context_only_ancestors(
+    instantiate_func: Any,
+) -> None:
+    config = OmegaConf.create(
+        {
+            "outer": {
+                "base": "???",
+                "inner": {
+                    "offset": "???",
+                    "target": {
+                        "_target_": "tests.instantiate.ArgsClass",
+                        "value": "${...base}",
+                        "offset": "${..offset}",
+                    },
+                },
+            }
+        }
+    )
+    OmegaConf.set_readonly(config, True)
+    merged_outer = OmegaConf.merge(config.outer, {"base": 10})
+    merged_inner = OmegaConf.merge(merged_outer.inner, {"offset": 20})
+
+    result = instantiate_func(merged_inner.target, extra=30)
+
+    assert result.kwargs == {"value": 10, "offset": 20, "extra": 30}
+    assert OmegaConf.is_missing(config.outer, "base")
+    assert OmegaConf.is_readonly(config)
 
 
 def test_callsite_runtime_object_is_visible_to_configured_interpolation(
@@ -975,6 +1076,179 @@ def test_non_recursive_config_argument_is_passed_directly_without_resolving(
     assert payload._get_flag("allow_objects")
     assert payload.alias == 10
     assert str(cfg) == original_config
+
+
+def test_no_override_config_is_readonly_during_instantiation_and_restored(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "_target_": "tests.instantiate.test_instantiate.ConfigMutationProbe",
+            "_recursive_": False,
+            "payload": {"value": 10},
+        }
+    )
+    OmegaConf.set_readonly(cfg.payload, False)
+    original_readonly = cfg._get_node_flag("readonly")
+
+    result = instantiate_func(cfg)
+
+    assert result.readonly
+    assert result.mutation_blocked
+    assert result.payload.value == 10
+    assert cfg.payload.value == 10
+    assert cfg._get_node_flag("readonly") is original_readonly
+    assert cfg.payload._get_node_flag("readonly") is False
+    assert not OmegaConf.is_readonly(cfg.payload)
+
+
+def test_no_override_config_read_write_unlocks_nested_nodes(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "_target_": "tests.instantiate.test_instantiate.NestedConfigMutationProbe",
+            "_recursive_": False,
+            "payload": {"child": {"value": 10}},
+        }
+    )
+
+    result = instantiate_func(cfg)
+
+    assert result.payload is cfg.payload
+    assert cfg.payload.child.value == 20
+    assert not OmegaConf.is_readonly(cfg.payload)
+    assert not OmegaConf.is_readonly(cfg.payload.child)
+
+
+def test_no_override_interpolated_config_is_readonly_during_instantiation(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "shared": {"value": 10},
+            "node": {
+                "_target_": "tests.instantiate.test_instantiate.ConfigMutationProbe",
+                "_recursive_": False,
+                "payload": "${..shared}",
+            },
+        }
+    )
+    OmegaConf.set_readonly(cfg.shared, False)
+
+    result = instantiate_func(cfg.node)
+
+    assert result.payload is cfg.shared
+    assert result.readonly
+    assert result.mutation_blocked
+    assert cfg.shared.value == 10
+    assert not OmegaConf.is_readonly(cfg.shared)
+
+
+def test_no_override_context_only_interpolated_config_is_readonly(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "factory": {
+                "shared": {"value": "???"},
+                "node": {
+                    "_target_": "tests.instantiate.test_instantiate.ConfigMutationProbe",
+                    "_recursive_": False,
+                    "payload": "${..shared}",
+                },
+            }
+        }
+    )
+    merged = OmegaConf.merge(cfg.factory, {"shared": {"value": 10}})
+    OmegaConf.set_readonly(merged.shared, False)
+
+    result = instantiate_func(merged.node)
+
+    assert result.payload is merged.shared
+    assert result.readonly
+    assert result.mutation_blocked
+    assert merged.shared.value == 10
+    assert not OmegaConf.is_readonly(merged.shared)
+
+
+def test_native_config_remains_writable_during_instantiation(
+    instantiate_func: Any,
+) -> None:
+    cfg = {
+        "_target_": "tests.instantiate.test_instantiate.ConfigMutationProbe",
+        "_recursive_": False,
+        "payload": {"value": 10},
+    }
+
+    result = instantiate_func(cfg)
+
+    assert not result.readonly
+    assert not result.mutation_blocked
+    assert result.payload.value == 20
+    assert cfg["payload"]["value"] == 10
+
+
+def test_private_config_copy_remains_writable(instantiate_func: Any) -> None:
+    cfg = OmegaConf.create(
+        {
+            "_target_": "tests.instantiate.test_instantiate.ConfigMutationProbe",
+            "_recursive_": False,
+            "payload": {"value": 10},
+        }
+    )
+
+    result = instantiate_func(cfg, _convert_="none")
+
+    assert not result.readonly
+    assert not result.mutation_blocked
+    assert result.payload.value == 20
+    assert cfg.payload.value == 10
+
+
+def test_top_level_sequence_is_readonly_during_instantiation_and_restored(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        [
+            {
+                "_target_": "tests.instantiate.test_instantiate.ConfigMutationProbe",
+                "_recursive_": False,
+                "payload": {"value": 10},
+            }
+        ]
+    )
+    OmegaConf.set_readonly(cfg[0].payload, False)
+    original_readonly = cfg._get_node_flag("readonly")
+
+    result = instantiate_func(cfg)
+
+    assert result[0].readonly
+    assert result[0].mutation_blocked
+    assert cfg[0].payload.value == 10
+    assert cfg._get_node_flag("readonly") is original_readonly
+    assert cfg[0].payload._get_node_flag("readonly") is False
+
+
+def test_no_override_config_readonly_is_restored_after_failure(
+    instantiate_func: Any,
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "_target_": "tests.instantiate.test_instantiate.ConfigMutationProbe",
+            "_recursive_": False,
+            "payload": {"value": 10},
+            "fail": True,
+        }
+    )
+    original_readonly = cfg._get_node_flag("readonly")
+
+    with raises(InstantiationException, match="expected failure"):
+        instantiate_func(cfg)
+
+    assert cfg.payload.value == 10
+    assert cfg._get_node_flag("readonly") is original_readonly
+    assert not OmegaConf.is_readonly(cfg.payload)
 
 
 def test_non_recursive_config_argument_uses_source_resolver_cache(

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -183,6 +183,10 @@ source configuration read-only, including while target constructors run, and
 restores its previous state before returning. Constructors can use OmegaConf's
 `read_write()` context manager to opt in to mutation explicitly.
 
+Hydra `_partial_` factories cannot be pickled before invocation. Invoke the
+factory first; whether the constructed object can be pickled is determined by
+that object's type.
+
 Primitive values, native `list`, `tuple`, and `dict` containers, and OmegaConf
 containers passed at the call-site retain Hydra's normal configuration
 semantics, including instantiation and conversion where applicable.

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -178,7 +178,10 @@ without call-site overrides do not make an additional input copy. When
 overrides are present, Hydra uses a private copy so configured interpolations
 resolve against the call-site values while leaving the input unchanged. Runtime
 state established by an earlier target can still be used while resolving a
-later argument.
+later argument. During copy-free instantiation, Hydra temporarily marks the
+source configuration read-only, including while target constructors run, and
+restores its previous state before returning. Constructors can use OmegaConf's
+`read_write()` context manager to opt in to mutation explicitly.
 
 Primitive values, native `list`, `tuple`, and `dict` containers, and OmegaConf
 containers passed at the call-site retain Hydra's normal configuration

--- a/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
+++ b/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
@@ -31,7 +31,8 @@ This has several benefits:
   overrides, Hydra no longer makes a final copy of OmegaConf containers before
   the target call. Containers passed through from the input tree retain their
   identity, lazy interpolations, ancestor context, resolver cache, and inherited
-  flags.
+  flags. Hydra temporarily marks the source configuration read-only during
+  instantiation and restores its previous state afterward.
 
 ## Compatibility impact
 
@@ -175,12 +176,15 @@ eagerly resolving the full configuration.
 With `_recursive_=False`, `_convert_="none"`, and no call-site overrides,
 OmegaConf containers are no longer copied and detached before the target call.
 The target receives the same `DictConfig`, `ListConfig`, or `TupleConfig`
-object from the input tree. Mutations made by the target are therefore visible
-through the original configuration, and an attached subtree retains its
-ancestor configuration when stored or serialized. When call-site overrides
-are present, configured containers come from Hydra's private resolution copy.
-Containers supplied directly as call-site values still retain their identity.
-Other conversion modes retain their documented conversion behavior.
+object from the input tree, temporarily marked read-only for the duration of
+instantiation, including the target constructor call. Hydra restores the
+configuration's previous read-only state before returning. A constructor that
+intentionally needs to mutate the source configuration can opt in explicitly
+with OmegaConf's `read_write()` context manager. When call-site overrides are
+present, configured containers come from Hydra's private resolution copy, and
+Hydra does not add this temporary read-only guard. Containers supplied directly
+as call-site values still retain their identity. Other conversion modes retain
+their documented conversion behavior.
 
 To pass an independent Config object instead, create one explicitly:
 


### PR DESCRIPTION

Reconstruct context-only merged ancestors in the private override tree so interpolations retain values produced by OmegaConf.merge.

Temporarily mark source configs read-only during copy-free instantiation while allowing targets to opt into mutation with OmegaConf read_write().

Fixes #3436