### PR TITLE
Avoid full compose when discovering hydra.mode

### DIFF
--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -5,7 +5,7 @@ import string
 import sys
 from argparse import ArgumentParser
 from collections import defaultdict
-from typing import Any, Callable, DefaultDict, List, Optional, Sequence, Type, Union
+from typing import Any, Callable, DefaultDict, List, Optional, Sequence, Tuple, Type, Union
 
 from omegaconf import (
     MISSING,
@@ -37,6 +37,9 @@ from hydra.plugins.config_source import ConfigSource
 from hydra.plugins.launcher import Launcher
 from hydra.plugins.search_path_plugin import SearchPathPlugin
 from hydra.plugins.sweeper import Sweeper
+from hydra.core.override_parser.overrides_parser import OverridesParser
+from hydra.errors import OverrideParseException
+from hydra.plugins.config_source import ConfigLoadError
 from hydra.types import HydraContext, RunMode, TaskFunction
 
 from ..core.default_element import DefaultsTreeNode, InputDefault
@@ -45,6 +48,68 @@ from .config_loader_impl import ConfigLoaderImpl
 from .utils import create_automatic_config_search_path
 
 log: Optional[logging.Logger] = None
+
+
+def _coerce_run_mode(value: Any) -> Optional[RunMode]:
+    if value is None:
+        return None
+    if isinstance(value, RunMode):
+        return value
+    if isinstance(value, str):
+        try:
+            return RunMode[value]
+        except KeyError:
+            return None
+    return None
+
+
+def _mode_from_overrides(overrides: List[str]) -> Tuple[bool, Optional[RunMode]]:
+    """Return (found, mode) for a hydra.mode override.
+
+    ``found`` is True if any override targeted ``hydra.mode`` (including deletes).
+    """
+    try:
+        parsed = OverridesParser.create().parse_overrides(overrides)
+    except OverrideParseException:
+        return False, None
+
+    found = False
+    mode: Optional[RunMode] = None
+    for override in parsed:
+        if override.key_or_group != "hydra.mode":
+            continue
+        found = True
+        if override.is_delete():
+            mode = None
+        else:
+            mode = _coerce_run_mode(override.value())
+    return found, mode
+
+
+def _mode_from_primary_config(
+    config_loader: ConfigLoader, config_name: Optional[str]
+) -> Optional[RunMode]:
+    """Read hydra.mode from the primary config file only (no defaults traversal)."""
+    if config_name is None:
+        return None
+    if not isinstance(config_loader, ConfigLoaderImpl):
+        return None
+    try:
+        loaded = config_loader.repository.load_config(config_path=config_name)
+    except ConfigLoadError:
+        return None
+    if loaded is None:
+        return None
+    mode_node = OmegaConf.select(loaded.config, "hydra.mode", default=None)
+    if mode_node is None:
+        return None
+    # Resolve self-contained interpolations such as ${oc.env:...} without composing.
+    try:
+        cfg = OmegaConf.create({"hydra": {"mode": mode_node}})
+        OmegaConf.resolve(cfg)
+        return _coerce_run_mode(cfg.hydra.mode)
+    except Exception:
+        return _coerce_run_mode(mode_node)
 
 
 def _resolve_node_interpolations(cfg: Any) -> None:
@@ -126,17 +191,15 @@ class Hydra:
         config_name: Optional[str],
         overrides: List[str],
     ) -> Any:
-        try:
-            cfg = self.compose_config(
-                config_name=config_name,
-                overrides=overrides,
-                with_log_configuration=False,
-                run_mode=RunMode.MULTIRUN,
-                validate_sweep_overrides=False,
-            )
-            return cfg.hydra.mode
-        except Exception:
-            return None
+        """Discover hydra.mode without a full compose probe (#3440).
+
+        Prefer a command-line ``hydra.mode`` override; otherwise read the primary
+        config file only. Returns None when unset so flag-based dispatch applies.
+        """
+        found, mode = _mode_from_overrides(overrides)
+        if found:
+            return mode
+        return _mode_from_primary_config(self.config_loader, config_name)
 
     def run(
         self,

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1982,3 +1982,31 @@ def test_hydra_runtime_choice_1882(tmpdir: Path) -> None:
         from_name="Expected output",
         to_name="Actual output",
     )
+
+
+def test_get_mode_does_not_compose(tmpdir: Path) -> None:
+    """Mode discovery must not run a full compose probe (#3440)."""
+    from hydra import initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+    from hydra.types import RunMode
+
+    conf_dir = Path(tmpdir) / "conf"
+    conf_dir.mkdir()
+    (conf_dir / "config.yaml").write_text(
+        "hydra:\n  mode: MULTIRUN\nx: 1\n", encoding="utf-8"
+    )
+
+    with initialize_config_dir(config_dir=str(conf_dir), job_name="test_get_mode"):
+        hydra = GlobalHydra.instance().hydra
+        assert hydra is not None
+
+        def boom(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("compose_config should not run during get_mode")
+
+        hydra.compose_config = boom  # type: ignore[method-assign]
+        assert hydra.get_mode(config_name="config", overrides=[]) == RunMode.MULTIRUN
+        assert (
+            hydra.get_mode(config_name="config", overrides=["hydra.mode=RUN"])
+            == RunMode.RUN
+        )
+        assert hydra.get_mode(config_name="config", overrides=["x=2"]) == RunMode.MULTIRUN

--- a/website/docs/tutorials/basic/running_your_app/2_multirun.md
+++ b/website/docs/tutorials/basic/running_your_app/2_multirun.md
@@ -10,9 +10,18 @@ E.g. running a performance test on each of the databases with each of the schema
 You can multirun a Hydra application via either commandline or configuration:
 
 ### Configure `hydra.mode` (new in Hydra 1.2)
-You can configure `hydra.mode` in any supported way. The legal values are `RUN` and `MULTIRUN`.
+You can set `hydra.mode` from the command line or in the primary config file.
+The legal values are `RUN` and `MULTIRUN`.
 The following shows how to override from the command-line and sweep over all combinations of the dbs and schemas.
-Setting `hydra.mode=MULTIRUN` in your input config would make your application multi-run by default.
+Setting `hydra.mode=MULTIRUN` in your primary config makes your application multi-run by default.
+
+:::note
+`hydra.mode` is read before full config composition. Values that only appear
+through a defaults-list / config-group entry, or that need other composed nodes
+to interpolate, are not discovered for run/multirun dispatch. Prefer a primary
+config literal (or a self-contained resolver such as `${oc.env:...}`) or a
+command-line override.
+:::
 
 ```text title="$ python my_app.py hydra.mode=MULTIRUN db=mysql,postgresql schema=warehouse,support,school"
 [2021-01-20 17:25:03,317][HYDRA] Launching 6 jobs locally


### PR DESCRIPTION
## Contributor License Agreement

Hydra requires contributors to accept its
[Individual Contributor License Agreement](https://hydra.cc/legal/individual-cla/).
CLA Assistant will check the pull request and provide a signing link if needed.
Obtain any approval required by your employer or other obligations before
signing.

## Motivation

Every app start was composing the config twice: once in `get_mode()` just to
read `hydra.mode`, then again in `run()` / `multirun()`. That matches the
diagnosis and proposed fix in #3440.

`get_mode()` now:

1. Reads `hydra.mode` from command-line overrides when present.
2. Otherwise loads only the primary config file (no defaults-list traversal).
3. Returns `None` when unset so flag-based dispatch behaves as before.

Docs note the intentional limit: mode values that only appear via a
defaults-list / config-group entry are no longer used for dispatch.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/hydra-ecosystem/hydra/blob/main/CONTRIBUTING.md)?

Yes

### For non-trivial features, API changes, or behavior changes: is there an issue or design discussion where maintainers agreed on the direction?

#3440 (proposal from @omry)

## Test Plan

- `pytest tests/test_hydra.py::test_get_mode_does_not_compose` (new: asserts
  `compose_config` is not called)
- `pytest tests/test_hydra.py::test_hydra_mode` (existing matrix still passes)

## Related Issues and PRs

Closes #3440
