### PR TITLE
feat: support Optuna v5 in the hydra plugin sweeper

### DIFF
--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -47,6 +47,7 @@ log = logging.getLogger(__name__)
 def create_nsgaii_sampler(
     mutation: Optional[Any] = None, **kwargs: Any
 ) -> optuna.samplers.NSGAIISampler:
+    # Optuna v5 adds mutation; omit it when unset for v4 compatibility.
     if mutation is not None:
         kwargs["mutation"] = mutation
     return optuna.samplers.NSGAIISampler(**kwargs)
@@ -59,6 +60,7 @@ def create_nsgaiii_sampler(
 ) -> optuna.samplers.NSGAIIISampler:
     if (points := reference_points) is not None:
         kwargs["reference_points"] = numpy.asarray(points, dtype=float)
+    # Optuna v5 adds mutation; omit it when unset for v4 compatibility.
     if mutation is not None:
         kwargs["mutation"] = mutation
     return optuna.samplers.NSGAIIISampler(**kwargs)

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -7,10 +7,12 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     MutableSequence,
     Optional,
     Sequence,
     Tuple,
+    cast,
 )
 
 import numpy
@@ -291,7 +293,7 @@ class OptunaSweeperImpl(Sweeper):
             study_name=self.study_name,
             storage=self.storage,
             sampler=self.sampler,
-            directions=directions,
+            directions=cast(List[Literal["minimize", "maximize"]], directions),
             load_if_exists=True,
         )
         log.info(f"Study name: {study.study_name}")

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -44,12 +44,23 @@ from .config import Direction
 log = logging.getLogger(__name__)
 
 
+def create_nsgaii_sampler(
+    mutation: Optional[Any] = None, **kwargs: Any
+) -> optuna.samplers.NSGAIISampler:
+    if mutation is not None:
+        kwargs["mutation"] = mutation
+    return optuna.samplers.NSGAIISampler(**kwargs)
+
+
 def create_nsgaiii_sampler(
     reference_points: Optional[List[List[float]]] = None,
+    mutation: Optional[Any] = None,
     **kwargs: Any,
 ) -> optuna.samplers.NSGAIIISampler:
     if (points := reference_points) is not None:
         kwargs["reference_points"] = numpy.asarray(points, dtype=float)
+    if mutation is not None:
+        kwargs["mutation"] = mutation
     return optuna.samplers.NSGAIIISampler(**kwargs)
 
 

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -99,11 +99,12 @@ class NSGAIISamplerConfig(SamplerConfig):
     https://optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.NSGAIISampler.html
     """
 
-    _target_: str = "optuna.samplers.NSGAIISampler"
+    _target_: str = "hydra_plugins.hydra_optuna_sweeper._impl.create_nsgaii_sampler"
     seed: Optional[int] = None
 
     population_size: int = 50
     mutation_prob: Optional[float] = None
+    mutation: Optional[Any] = None
     crossover: Optional[Any] = None
     crossover_prob: float = 0.9
     swapping_prob: float = 0.5
@@ -121,6 +122,7 @@ class NSGAIIISamplerConfig(SamplerConfig):
 
     population_size: int = 50
     mutation_prob: Optional[float] = None
+    mutation: Optional[Any] = None
     crossover: Optional[Any] = None
     crossover_prob: float = 0.9
     swapping_prob: float = 0.5

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -29,7 +29,7 @@ setup(
     python_requires=">=3.10",
     install_requires=[
         "hydra-core>=1.1.0.dev7",
-        "optuna>=4.9.0,<5.0.0",
+        "optuna>=4.9.0,<6.0.0",
     ],
     include_package_data=True,
 )

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -4,7 +4,7 @@ import sys
 import warnings
 from pathlib import Path
 from typing import Any, List
-from unittest.mock import patch
+from unittest.mock import patch, sentinel
 
 import numpy
 import optuna
@@ -414,19 +414,27 @@ def test_motpe_sampler_removed() -> None:
         (NSGAIIISamplerConfig, optuna.samplers.NSGAIIISampler),
     ],
 )
-def test_nsga_sampler_omits_default_mutation(
-    config_type: Any, sampler_type: Any
+@mark.parametrize("mutation", [None, sentinel.mutation])
+def test_nsga_sampler_mutation(
+    config_type: Any, sampler_type: Any, mutation: Any
 ) -> None:
+    config = OmegaConf.structured(config_type, flags={"allow_objects": True})
+    assert config.mutation is None
+    config.mutation = mutation
     with patch.object(sampler_type, "__init__", return_value=None) as constructor:
         instantiate(
-            OmegaConf.structured(config_type),
+            config,
             _execution_whitelist_=(
                 "optuna.samplers.*",
+                "hydra_plugins.hydra_optuna_sweeper._impl.create_nsgaii_sampler",
                 "hydra_plugins.hydra_optuna_sweeper._impl.create_nsgaiii_sampler",
             ),
         )
     constructor.assert_called_once()
-    assert "mutation" not in constructor.call_args.kwargs
+    if mutation is None:
+        assert "mutation" not in constructor.call_args.kwargs
+    else:
+        assert constructor.call_args.kwargs["mutation"] is mutation
 
 
 @mark.filterwarnings("default:NSGAIIISampler is experimental")

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -407,6 +407,28 @@ def test_motpe_sampler_removed() -> None:
         )
 
 
+@mark.parametrize(
+    "config_type, sampler_type",
+    [
+        (NSGAIISamplerConfig, optuna.samplers.NSGAIISampler),
+        (NSGAIIISamplerConfig, optuna.samplers.NSGAIIISampler),
+    ],
+)
+def test_nsga_sampler_omits_default_mutation(
+    config_type: Any, sampler_type: Any
+) -> None:
+    with patch.object(sampler_type, "__init__", return_value=None) as constructor:
+        instantiate(
+            OmegaConf.structured(config_type),
+            _execution_whitelist_=(
+                "optuna.samplers.*",
+                "hydra_plugins.hydra_optuna_sweeper._impl.create_nsgaiii_sampler",
+            ),
+        )
+    constructor.assert_called_once()
+    assert "mutation" not in constructor.call_args.kwargs
+
+
 @mark.filterwarnings("default:NSGAIIISampler is experimental")
 def test_nsgaiii_sampler_reference_points_converted_to_array() -> None:
     reference_points = [[0.0, 1.0], [1.0, 0.0]]


### PR DESCRIPTION
Support Optuna 4.9 and 5.x while preserving Hydra's existing sampler defaults. See the [Optuna v5.0.0 release notes](https://github.com/optuna/optuna/releases/tag/v5.0.0).

- Keep `multivariate=False`. Optuna v5 defaults to `None`, enabling multivariate sampling for single-objective studies and disabling it for multi-objective studies under the default `group=False`.
- Keep `constant_liar=False`, although Optuna v5 defaults to `True`.
- Add optional `mutation` configuration for NSGA-II and NSGA-III, omitting the argument when unset and forwarding configured objects unchanged.

Dropping v4 support would require users to install Optuna v5 and let us remove the mutation-argument omission logic. We could also separately adopt `multivariate=None` as Hydra's default, enabling multivariate sampling for single-objective studies. Users could retain the previous behavior by explicitly setting `multivariate=false`.


🔗. https://github.com/optuna/optuna/pull/6766 (multivariate)
🔗. https://github.com/optuna/optuna/pull/6724 (mutation)